### PR TITLE
Specify license in gemspec

### DIFF
--- a/curly-templates.gemspec
+++ b/curly-templates.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
 
   s.summary     = "Free your views!"
   s.description = "A view layer for your Rails apps that separates structure and logic."
+  s.license     = "apache2"
 
   s.authors  = ["Daniel Schierbeck"]
   s.email    = 'daniel.schierbeck@gmail.com'


### PR DESCRIPTION
Makes it possible to use tools like https://github.com/pivotal/LicenseFinder
