### PR TITLE
Remove template digests

### DIFF
--- a/lib/curly/template_handler.rb
+++ b/lib/curly/template_handler.rb
@@ -28,7 +28,6 @@ class Curly::TemplateHandler
       presenter_class = Curly::Presenter.presenter_for_path(path)
 
       source = Curly.compile(template.source, presenter_class)
-      template_digest = Digest::MD5.hexdigest(template.source)
 
       <<-RUBY
       if local_assigns.empty?
@@ -46,8 +45,6 @@ class Curly::TemplateHandler
       if key = presenter.cache_key
         @output_buffer = ActiveSupport::SafeBuffer.new
 
-        template_digest = #{template_digest.inspect}
-
         if #{presenter_class}.respond_to?(:cache_key)
           presenter_key = #{presenter_class}.cache_key
         else
@@ -58,7 +55,7 @@ class Curly::TemplateHandler
           expires_in: presenter.cache_duration
         }
 
-        cache([template_digest, key, presenter_key].compact, options) do
+        cache([key, presenter_key].compact, options) do
           safe_concat(view_function.call)
         end
 

--- a/spec/template_handler_spec.rb
+++ b/spec/template_handler_spec.rb
@@ -123,16 +123,6 @@ describe Curly::TemplateHandler do
       output.should == "BAZ"
     end
 
-    it "adds a digest of the template source to the cache key" do
-      context.assigns[:cache_key] = "x"
-
-      template.stub(:source) { "{{bar}}" }
-      output.should == "BAR"
-
-      template.stub(:source) { "FOO{{bar}}" }
-      output.should == "FOOBAR"
-    end
-
     it "adds the presenter class' cache key to the instance's cache key" do
       # Make sure caching is enabled
       context.assigns[:cache_key] = "x"


### PR DESCRIPTION
They don't really belong in Curly – use the Cache Digests gem if you want the functionality.
