### PR TITLE
Allow optional presenter parameters

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -44,8 +44,15 @@ module Curly
     #
     def initialize(context, options = {})
       @_context = context
+
       self.class.presented_names.each do |name|
-        instance_variable_set("@#{name}", options.fetch(name))
+        value = options.fetch(name)
+        instance_variable_set("@#{name}", value)
+      end
+
+      self.class.optional_presented_names.each do |name|
+        value = options.fetch(name, nil)
+        instance_variable_set("@#{name}", value)
       end
     end
 
@@ -209,7 +216,13 @@ module Curly
       end
 
       def presents(*args)
-        self.presented_names += args
+        options = args.extract_options!
+
+        if options[:optional]
+          self.optional_presented_names += args
+        else
+          self.presented_names += args
+        end
       end
     end
 
@@ -217,6 +230,9 @@ module Curly
 
     class_attribute :presented_names
     self.presented_names = [].freeze
+
+    class_attribute :optional_presented_names
+    self.optional_presented_names = [].freeze
 
     # Delegates private method calls to the current view context.
     #

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -10,7 +10,8 @@ describe Curly::Presenter do
     include MonkeyComponents
 
     presents :midget, :clown
-    attr_reader :midget, :clown
+    presents :line_dancer, optional: true
+    attr_reader :midget, :clown, :line_dancer
   end
 
   it "sets the presented parameters as instance variables" do
@@ -23,6 +24,25 @@ describe Curly::Presenter do
 
     presenter.midget.should == "Meek Harolson"
     presenter.clown.should == "Bubbles"
+  end
+
+  it "allows specifying optional parameters" do
+    context = double("context")
+
+    presenter = CircusPresenter.new(context,
+      midget: "Meek Harolson",
+      clown: "Bubbles"
+    )
+
+    presenter.line_dancer.should be_nil
+
+    presenter = CircusPresenter.new(context,
+      midget: "Meek Harolson",
+      clown: "Bubbles",
+      line_dancer: "Miss Universe"
+    )
+
+    presenter.line_dancer.should == "Miss Universe"
   end
 
   describe ".presenter_for_path" do


### PR DESCRIPTION
This PR would allow presenter classes to specify a list of optional parameters that would default to nil, e.g.

``` ruby
class CircusPresenter < Curly::Presenter
  presents :sprechtallsmeister
  presents :clown, optional: true
end
```
