### PR TITLE
Allow comments in Curly template

### DIFF
--- a/lib/curly/compiler.rb
+++ b/lib/curly/compiler.rb
@@ -19,11 +19,15 @@ module Curly
         end
 
         source = template.dup
+
+        # Escape double quotes.
+        source.gsub!('"', '\"')
+
         source.gsub!(REFERENCE_REGEX) { compile_reference($1, presenter_class) }
         source.gsub!(COMMENT_LINE_REGEX) { compile_comment_line($1) }
         source.gsub!(COMMENT_REGEX) { compile_comment($1) }
 
-        '%%(%s)' % source
+        '"%s"' % source
       end
 
       # Whether the Curly template is valid. This includes whether all

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -85,6 +85,10 @@ describe Curly::Compiler do
       evaluate("{{yield_value}}") {|v| v.upcase }.should == "FOO, please?"
     end
 
+    it "properly handles quotes in the template" do
+      evaluate('"').should == '"'
+    end
+
     it "escapes non HTML safe strings returned from the presenter" do
       presenter.stub(:dirty) { "<p>dirty</p>" }
       evaluate("{{dirty}}").should == "&lt;p&gt;dirty&lt;/p&gt;"


### PR DESCRIPTION
Comments will be stripped when the template is compiled.
### Examples

``` html
<h1>Hello!</h1>

{{! This comment takes up the entire line, so the line will be stripped }}
<p>Wunderbar!</p>

You can also use {{! inline comments }} - these are simple removed from the line.
```
