### PR TITLE
Add projections for vim-rails

### DIFF
--- a/lib/rails/projections.json
+++ b/lib/rails/projections.json
@@ -1,0 +1,16 @@
+{
+  "app/presenters/*_presenter.rb": {
+    "affinity": "controller",
+    "command": "presenter",
+    "test": "spec/presenters/%s_presenter_spec.rb",
+    "related": "app/views/%s.html.curly",
+    "template": "class %SPresenter < Curly::Presenter\nend",
+    "keywords": "presents depends_on version"
+  },
+
+  "app/views/*.html.curly": {
+    "affinity": "controller",
+    "test": "spec/views/%s_spec.rb",
+    "related": "app/presenters/%s_presenter.rb"
+  }
+}


### PR DESCRIPTION
Allows jumping between a presenter and a template using `:R`.

This goes out to all the Vim afficionados out there!
