### PR TITLE
Allow setting content variables using a special syntax

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -90,6 +90,16 @@ module Curly
       nil
     end
 
+    def content_for_values
+      content_keys = methods.map do |method|
+        method[/^content_for_(\w+)\!$/, 1]
+      end.compact
+
+      content_keys.inject(Hash.new) do |hash, key|
+        hash.merge(key.to_sym => send("content_for_#{key}!"))
+      end
+    end
+
     class << self
 
       # The name of the presenter class for a given view path.

--- a/lib/curly/template_handler.rb
+++ b/lib/curly/template_handler.rb
@@ -42,6 +42,10 @@ class Curly::TemplateHandler
         #{source}
       end
 
+      presenter.content_for_values.each do |key, value|
+        content_for(key, value)
+      end
+
       if key = presenter.cache_key
         @output_buffer = ActiveSupport::SafeBuffer.new
 

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -13,6 +13,10 @@ describe Curly::Presenter do
     presents :elephant, default: "Dumbo"
 
     attr_reader :midget, :clown, :elephant
+
+    def content_for_circus_name!
+      "Circus Arli"
+    end
   end
 
   class FrenchCircusPresenter < CircusPresenter
@@ -41,6 +45,15 @@ describe Curly::Presenter do
     # The subclass shouldn't change the superclass' defaults, though.
     presenter = CircusPresenter.new(context)
     presenter.elephant.should == "Dumbo"
+  end
+
+  describe "#content_for_values" do
+    it "returns a hash of the content_for key-value pairs" do
+      context = double("context")
+      presenter = CircusPresenter.new(context)
+
+      presenter.content_for_values.should == { circus_name: "Circus Arli" }
+    end
   end
 
   describe ".presenter_for_path" do

--- a/spec/template_handler_spec.rb
+++ b/spec/template_handler_spec.rb
@@ -17,6 +17,10 @@ describe Curly::TemplateHandler do
         @context.bar
       end
 
+      def content_for_values
+        { dinglebats: "wombah!" }
+      end
+
       def cache_key
         @cache_key
       end
@@ -45,6 +49,12 @@ describe Curly::TemplateHandler do
 
       def advance_clock(duration)
         @clock += duration
+      end
+
+      def content_for(key, value = nil)
+        @contents ||= {}
+        @contents[key] = value if value.present?
+        @contents[key]
       end
 
       def cache(key, options = {})
@@ -152,6 +162,11 @@ describe Curly::TemplateHandler do
       # Now it has! Huzzah!
       context.advance_clock(1)
       output.should == "FOO"
+    end
+
+    it "sets all content variables using #content_for" do
+      output
+      context.content_for(:dinglebats).should == "wombah!"
     end
   end
 


### PR DESCRIPTION
This is still experimental.

By defining methods starting with `content_for_` and ending in `!`,
variables can be set at render time.

``` ruby
class RocketPresenter < Curly::Presenter
  # Same as calling `content_for :rocket_name, "Apollo"` in an
  # ERB template.
  def content_for_rocket_name!
    "Apollo"
  end
end
```
### Alternative designs
#### Allow calling arbitrary code via a `setup!` method

This is very easy to do – simply call the `setup!` method on the presenter just before rendering the view. The presenter can specify `content_for` values and whatnot:

``` ruby
class RocketPresenter < Curly::Presenter
  def setup!
    content_for :rocket_name, "Apollo"
  end
end
```
#### Add a special DSL

This would add some complexity, but would in turn not pollute the method namespace.

``` ruby
class RocketPresenter < Curly::Presenter
  content_for :rocket_name do
    # Evaluated at render time.
    "Apollo"
  end
end
```
