### PR TITLE
Allow escaping Curly

### DIFF
--- a/lib/curly/scanner.rb
+++ b/lib/curly/scanner.rb
@@ -13,7 +13,6 @@ module Curly
     CURLY_END = /\}\}/
 
     ESCAPED_CURLY_START = /\{\{\{/
-    ESCAPED_CURLY_END = /\}\}\}/
 
     COMMENT_MARKER = /!/
 
@@ -55,8 +54,6 @@ module Curly
     def scan_escaped_curly
       if @scanner.scan(ESCAPED_CURLY_START)
         [:text, "{{"]
-      elsif @scanner.scan(ESCAPED_CURLY_END)
-        [:text, "}}"]
       end
     end
 
@@ -111,7 +108,7 @@ module Curly
     end
 
     def scan_until_end_of_curly
-      if value = @scanner.scan_until(CURLY_END)     
+      if value = @scanner.scan_until(CURLY_END)
         value[0..-3]
       end
     end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -52,12 +52,10 @@ describe Curly::Scanner, ".scan" do
       [:text, "foo }} bar"]
     ]
 
-    scan('foo {{{ lala! }}} bar').should == [
+    scan('foo {{{ lala! }} bar').should == [
       [:text, "foo "],
       [:text, "{{"],
-      [:text, " lala! "],
-      [:text, "}}"],
-      [:text, " bar"],
+      [:text, " lala! }} bar"]
     ]
   end
 


### PR DESCRIPTION
The current plan is to add a triple-curly syntax for escaped curly quotes: `{{{ hello! }}}` will be compiled to `{{ hello! }}`.
