### PR TITLE
Add conditional blocks to templates

### DIFF
--- a/lib/curly/invalid_block_error.rb
+++ b/lib/curly/invalid_block_error.rb
@@ -1,0 +1,32 @@
+module Curly
+  class InvalidBlockError < StandardError
+
+    attr_reader :reference
+
+    def initialize(reference)
+      @reference = reference
+    end
+
+  end
+
+  class IncompleteBlockError < InvalidBlockError
+
+    def message
+      "error compiling `{{##{@reference}}}`: Conditional block must be terminated with `{{/#{@reference}}}}`"
+    end
+
+  end
+
+  class IncorrectEndingError < InvalidBlockError
+
+    def initialize(reference, last_block)
+      @reference, @last_block = reference, last_block
+    end
+
+    def message
+      "error compiling `{{##{@last_block}}}`: expected `{{/#{@last_block}}}`, got `{{/#{@reference}}}`"
+    end
+
+  end
+
+end

--- a/lib/curly/scanner.rb
+++ b/lib/curly/scanner.rb
@@ -15,6 +15,10 @@ module Curly
     ESCAPED_CURLY_START = /\{\{\{/
 
     COMMENT_MARKER = /!/
+    BLOCK_MARKER = /#/
+    INVERSE_BLOCK_MARKER = /\^/
+    END_BLOCK_MARKER = /\//
+
 
     # Scans a Curly template for tokens.
     #
@@ -59,13 +63,19 @@ module Curly
 
     def scan_curly
       if @scanner.scan(CURLY_START)
-        scan_reference_or_comment or syntax_error!
+        scan_tag or syntax_error!
       end
     end
 
-    def scan_reference_or_comment
+    def scan_tag
       if @scanner.scan(COMMENT_MARKER)
         scan_comment
+      elsif @scanner.scan(BLOCK_MARKER)
+        scan_block_start
+      elsif @scanner.scan(INVERSE_BLOCK_MARKER)
+        scan_inverse_block_start
+      elsif @scanner.scan(END_BLOCK_MARKER)
+        scan_block_end
       else
         scan_reference
       end
@@ -74,6 +84,24 @@ module Curly
     def scan_comment
       if value = scan_until_end_of_curly
         [:comment, value]
+      end
+    end
+
+    def scan_block_start
+      if value = scan_until_end_of_curly
+        [:block_start, value]
+      end
+    end
+
+    def scan_inverse_block_start
+      if value = scan_until_end_of_curly
+        [:inverse_block_start, value]
+      end
+    end
+
+    def scan_block_end
+      if value = scan_until_end_of_curly
+        [:block_end, value]
       end
     end
 

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -59,6 +59,24 @@ describe Curly::Scanner, ".scan" do
     ]
   end
 
+  it "scans block tags" do
+    scan('foo {{#bar}} hello {{/bar}}').should == [
+      [:text, "foo "],
+      [:block_start, "bar"],
+      [:text, " hello "],
+      [:block_end, "bar"]
+    ]
+  end
+
+  it "scans inverse block tags" do
+    scan('foo {{^bar}} hello {{/bar}}').should == [
+      [:text, "foo "],
+      [:inverse_block_start, "bar"],
+      [:text, " hello "],
+      [:block_end, "bar"]
+    ]
+  end
+
   it "treats quotes as text" do
     scan('"').should == [
       [:text, '"']


### PR DESCRIPTION
Adds conditional blocks to the curly language.  I decided to go with Moustache's syntax, i.e.

```
{{#true?}}
something
{{/true?}}
```

I'm not sure if this is acceptable, since there was no `CONTRIBUTING.md`, but I added the tests for the scanner and compiler.  This should address #32, unfortunately, it doesn't block normal references (i.e. `{{true?}}`) from using a conditional.
