### PR TITLE
Extract each exception and add a common base class

### DIFF
--- a/lib/curly/compiler.rb
+++ b/lib/curly/compiler.rb
@@ -1,6 +1,9 @@
 require 'curly/scanner'
+require 'curly/error'
 require 'curly/invalid_reference'
 require 'curly/invalid_block_error'
+require 'curly/incorrect_ending_error'
+require 'curly/incomplete_block_error'
 
 module Curly
 
@@ -31,7 +34,7 @@ module Curly
       compile(template, presenter_class)
 
       true
-    rescue InvalidReference, InvalidBlockError
+    rescue Error
       false
     end
 

--- a/lib/curly/error.rb
+++ b/lib/curly/error.rb
@@ -1,0 +1,4 @@
+module Curly
+  class Error < StandardError
+  end
+end

--- a/lib/curly/incomplete_block_error.rb
+++ b/lib/curly/incomplete_block_error.rb
@@ -1,0 +1,11 @@
+module Curly
+  class IncompleteBlockError < Error
+    def initialize(reference)
+      @reference = reference
+    end
+
+    def message
+      "error compiling `{{##{@reference}}}`: conditional block must be terminated with `{{/#{@reference}}}}`"
+    end
+  end
+end

--- a/lib/curly/incorrect_ending_error.rb
+++ b/lib/curly/incorrect_ending_error.rb
@@ -1,0 +1,11 @@
+module Curly
+  class IncorrectEndingError < Error
+    def initialize(reference, last_block)
+      @reference, @last_block = reference, last_block
+    end
+
+    def message
+      "error compiling `{{##{@last_block}}}`: expected `{{/#{@last_block}}}`, got `{{/#{@reference}}}`"
+    end
+  end
+end

--- a/lib/curly/invalid_block_error.rb
+++ b/lib/curly/invalid_block_error.rb
@@ -1,32 +1,9 @@
 module Curly
-  class InvalidBlockError < StandardError
-
+  class InvalidBlockError < Error
     attr_reader :reference
 
     def initialize(reference)
       @reference = reference
     end
-
   end
-
-  class IncompleteBlockError < InvalidBlockError
-
-    def message
-      "error compiling `{{##{@reference}}}`: Conditional block must be terminated with `{{/#{@reference}}}}`"
-    end
-
-  end
-
-  class IncorrectEndingError < InvalidBlockError
-
-    def initialize(reference, last_block)
-      @reference, @last_block = reference, last_block
-    end
-
-    def message
-      "error compiling `{{##{@last_block}}}`: expected `{{/#{@last_block}}}`, got `{{/#{@reference}}}`"
-    end
-
-  end
-
 end

--- a/lib/curly/invalid_reference.rb
+++ b/lib/curly/invalid_reference.rb
@@ -1,5 +1,5 @@
 module Curly
-  class InvalidReference < StandardError
+  class InvalidReference < Error
     attr_reader :reference
 
     def initialize(reference)


### PR DESCRIPTION
It's now possible to rescue Curly::Error and get all the compilation errors.
