### PR TITLE
Allow rendering collections inline in templates

### DIFF
--- a/lib/curly/scanner.rb
+++ b/lib/curly/scanner.rb
@@ -15,8 +15,9 @@ module Curly
     ESCAPED_CURLY_START = /\{\{\{/
 
     COMMENT_MARKER = /!/
-    BLOCK_MARKER = /#/
+    CONDITIONAL_BLOCK_MARKER = /#/
     INVERSE_BLOCK_MARKER = /\^/
+    COLLECTION_BLOCK_MARKER = /\*/
     END_BLOCK_MARKER = /\//
 
 
@@ -70,10 +71,12 @@ module Curly
     def scan_tag
       if @scanner.scan(COMMENT_MARKER)
         scan_comment
-      elsif @scanner.scan(BLOCK_MARKER)
-        scan_block_start
+      elsif @scanner.scan(CONDITIONAL_BLOCK_MARKER)
+        scan_conditional_block_start
       elsif @scanner.scan(INVERSE_BLOCK_MARKER)
         scan_inverse_block_start
+      elsif @scanner.scan(COLLECTION_BLOCK_MARKER)
+        scan_collection_block_start
       elsif @scanner.scan(END_BLOCK_MARKER)
         scan_block_end
       else
@@ -87,21 +90,31 @@ module Curly
       end
     end
 
-    def scan_block_start
+    def scan_conditional_block_start
       if value = scan_until_end_of_curly
-        [:block_start, value]
+        [:conditional_block_start, value]
+      end
+    end
+
+    def scan_collection_block_start
+      if value = scan_until_end_of_curly
+        [:collection_block_start, value]
       end
     end
 
     def scan_inverse_block_start
       if value = scan_until_end_of_curly
-        [:inverse_block_start, value]
+        [:inverse_conditional_block_start, value]
       end
     end
 
     def scan_block_end
       if value = scan_until_end_of_curly
-        [:block_end, value]
+        if value.end_with?("?")
+          [:conditional_block_end, value]
+        else
+          [:collection_block_end, value]
+        end
       end
     end
 

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Curly::Compiler do
+  include CompilationSupport
+
   let :presenter_class do
     Class.new do
       def foo
@@ -184,18 +186,5 @@ describe Curly::Compiler do
     def validate(template)
       Curly.valid?(template, presenter_class)
     end
-  end
-
-  def evaluate(template, &block)
-    code = Curly::Compiler.compile(template, presenter_class)
-    context = double("context", presenter: presenter)
-
-    context.instance_eval(<<-RUBY)
-      def self.render
-        #{code}
-      end
-    RUBY
-
-    context.render(&block)
   end
 end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -59,21 +59,30 @@ describe Curly::Scanner, ".scan" do
     ]
   end
 
-  it "scans block tags" do
-    scan('foo {{#bar}} hello {{/bar}}').should == [
+  it "scans conditional block tags" do
+    scan('foo {{#bar?}} hello {{/bar?}}').should == [
       [:text, "foo "],
-      [:block_start, "bar"],
+      [:conditional_block_start, "bar?"],
       [:text, " hello "],
-      [:block_end, "bar"]
+      [:conditional_block_end, "bar?"]
     ]
   end
 
   it "scans inverse block tags" do
-    scan('foo {{^bar}} hello {{/bar}}').should == [
+    scan('foo {{^bar?}} hello {{/bar?}}').should == [
       [:text, "foo "],
-      [:inverse_block_start, "bar"],
+      [:inverse_conditional_block_start, "bar?"],
       [:text, " hello "],
-      [:block_end, "bar"]
+      [:conditional_block_end, "bar?"]
+    ]
+  end
+
+  it "scans collection block tags" do
+    scan('foo {{*bar}} hello {{/bar}}').should == [
+      [:text, "foo "],
+      [:collection_block_start, "bar"],
+      [:text, " hello "],
+      [:collection_block_end, "bar"]
     ]
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,18 @@ if ENV['CI']
 end
 
 require 'curly'
+
+module CompilationSupport
+  def evaluate(template, options = {}, &block)
+    code = Curly::Compiler.compile(template, presenter_class)
+    context = double("context")
+
+    context.instance_eval(<<-RUBY)
+      def self.render(presenter, options)
+        #{code}
+      end
+    RUBY
+
+    context.render(presenter, options, &block)
+  end
+end


### PR DESCRIPTION
Experimental implementation of #58.

The idea would be that if you have a view `groups/show`:

``` html
<h1>{{name}}</h1>
<h2>Members:</h2>
<ul>
{{*members}}
  <li><a href="{{url}}">{{name}}</a></li>
{{/members}}
</ul>
```

... and a presenter:

``` ruby
class Groups::ShowPresenter < Curly::Presenter
  presents :group

  def name; @group.name; end
  def members; @group.members; end
end
```

Then we'll try to wrap each "member" object in the presenter `Groups::ShowPresenter::MemberPresenter`. If the presenter doesn't exist in that namespace, it'll go down one level, i.e. `Groups::MemberPresenter`, and lastly it'll look at just `MemberPresenter`. This is how `const_get` works. That way, you can decide at which level to implement the presenter.

The presenter will look like this:

``` ruby
class Groups::MemberPresenter < Curly::Presenter
  presents :member

  def name; @member.name; end
  def url; user_path(@member); end
end
```
