### PR TITLE
Add support for deprecated methods

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -174,7 +174,7 @@ module Curly
       #
       # Returns an Array of Symbol method names.
       def available_methods
-        public_instance_methods - Curly::Presenter.public_instance_methods
+        public_instance_methods - Curly::Presenter.public_instance_methods - deprecated_methods
       end
 
       # The set of view paths that the presenter depends on.
@@ -253,14 +253,19 @@ module Curly
           self.default_values = self.default_values.merge(default_values)
         end
       end
+
+      def deprecate_methods(*args)
+        self.deprecated_methods += args
+      end
     end
 
     private
 
-    class_attribute :presented_names, :default_values
+    class_attribute :presented_names, :default_values, :deprecated_methods
 
     self.presented_names = [].freeze
     self.default_values = {}.freeze
+    self.deprecated_methods = [].freeze
 
     # Delegates private method calls to the current view context.
     #

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -12,7 +12,9 @@ describe Curly::Presenter do
     presents :midget, :clown, default: nil
     presents :elephant, default: "Dumbo"
 
-    attr_reader :midget, :clown, :elephant
+    attr_reader :midget, :clown, :elephant, :horse
+
+    deprecate_methods :horse
   end
 
   class FrenchCircusPresenter < CircusPresenter
@@ -82,6 +84,10 @@ describe Curly::Presenter do
 
     it "does not include methods on the Curly::Presenter base class" do
       CircusPresenter.available_methods.should_not include(:cache_key)
+    end
+
+    it "does not include deprecated methods" do
+      CircusPresenter.available_methods.should_not include(:horse)
     end
   end
 


### PR DESCRIPTION
Adds support for deprecated methods.

A deprecated method behaves exactly like a normal method, the only difference is that it is not returned in the list returned by `available_methods` class method.

An example:

``` rb
class CircusPresenter < Curly::Presenter
  attr_reader :midget, :clown, :elephant, :horse

  deprecate_methods :horse
end

...

circus_presenter.available_methods = [:midget, :clown, :elephant]
```
