### PR TITLE
Avoid creating Symbols based on user input

### DIFF
--- a/lib/curly/compiler.rb
+++ b/lib/curly/compiler.rb
@@ -88,8 +88,8 @@ module Curly
 
       @blocks.push reference
 
-      unless presenter_class.method_available?(method.to_sym)
-        raise Curly::InvalidReference.new(method.to_sym)
+      unless presenter_class.method_available?(method)
+        raise Curly::InvalidReference.new(method)
       end
 
       if presenter_class.instance_method(method).arity == 1
@@ -118,8 +118,8 @@ module Curly
     def compile_reference(reference)
       method, argument = reference.split(".", 2)
 
-      unless presenter_class.method_available?(method.to_sym)
-        raise Curly::InvalidReference.new(method.to_sym)
+      unless presenter_class.method_available?(method)
+        raise Curly::InvalidReference.new(method)
       end
 
       if presenter_class.instance_method(method).arity == 1

--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -162,7 +162,7 @@ module Curly
       #
       # This policy can be changed by overriding this method in your presenters.
       #
-      # method - The Symbol name of the method.
+      # method - The String name of the method.
       #
       # Returns true if the method can be referenced by a template,
       #   false otherwise.
@@ -172,9 +172,10 @@ module Curly
 
       # A list of methods available to templates rendered with the presenter.
       #
-      # Returns an Array of Symbol method names.
+      # Returns an Array of String method names.
       def available_methods
-        public_instance_methods - Curly::Presenter.public_instance_methods
+        methods = public_instance_methods - Curly::Presenter.public_instance_methods
+        methods.map(&:to_s)
       end
 
       # The set of view paths that the presenter depends on.

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -40,8 +40,7 @@ describe Curly::Compiler do
       end
 
       def self.method_available?(method)
-        [:foo, :parameterized, :high_yield, :yield_value, :dirty,
-          :false?, :true?, :hello?].include?(method)
+        %w[foo parameterized high_yield yield_value dirty false? true? hello?].include?(method)
       end
 
       def self.available_methods
@@ -86,7 +85,7 @@ describe Curly::Compiler do
         evaluate("{{bar}}")
         fail
       rescue Curly::InvalidReference => e
-        e.reference.should == :bar
+        e.reference.should == "bar"
       end
     end
 

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -77,21 +77,21 @@ describe Curly::Presenter do
 
   describe ".available_methods" do
     it "includes the methods on the presenter" do
-      CircusPresenter.available_methods.should include(:midget)
+      CircusPresenter.available_methods.should include("midget")
     end
 
     it "does not include methods on the Curly::Presenter base class" do
-      CircusPresenter.available_methods.should_not include(:cache_key)
+      CircusPresenter.available_methods.should_not include("cache_key")
     end
   end
 
   describe ".method_available?" do
     it "returns true if the method is available" do
-      CircusPresenter.method_available?(:midget).should == true
+      CircusPresenter.method_available?("midget").should == true
     end
 
     it "returns false if the method is not available" do
-      CircusPresenter.method_available?(:bear).should == false
+      CircusPresenter.method_available?("bear").should == false
     end
   end
 


### PR DESCRIPTION
This removes a potential security issue: if untrusted users are allowed to have templates compiled, they could use random reference names to allocate memory that won't be reclaimed by the garbage collector.

This changes the API of the `method_available?` protocol a bit, passing a String rather than a Symbol.
