### PR TITLE
Fix a bug related to attributes on conditional blocks

### DIFF
--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -27,6 +27,10 @@ describe Curly::Compiler do
         nil
       end
 
+      def square?(width:, height:)
+        width.to_i == height.to_i
+      end
+
       def false?
         false
       end
@@ -36,7 +40,7 @@ describe Curly::Compiler do
       end
 
       def self.method_available?(method)
-        %w[foo high_yield yield_value dirty false? true? hello?].include?(method)
+        %w[foo high_yield yield_value dirty false? true? hello? square?].include?(method)
       end
 
       def self.available_methods
@@ -126,6 +130,10 @@ describe Curly::Compiler do
 
     it "passes an argument to blocks" do
       evaluate("{{#hello.world?}}foo{{/hello.world?}}{{#hello.foo?}}bar{{/hello.foo?}}").should == "foo"
+    end
+
+    it "passes attributes to blocks" do
+      evaluate("{{#square? width=2 height=2}}yeah!{{/square? width=2 height=2}}").should == "yeah!"
     end
 
     it "gives an error on mismatching blocks" do

--- a/spec/reference_compiler_spec.rb
+++ b/spec/reference_compiler_spec.rb
@@ -1,93 +1,158 @@
 require 'spec_helper'
 
 describe Curly::ReferenceCompiler do
-  let(:presenter_class) do
-    Class.new do
-      def title
-        "Welcome!"
-      end
+  describe ".compile_conditional" do
+    let(:presenter_class) do
+      Class.new do
+        def monday?
+          true
+        end
 
-      def i18n(key, fallback: nil)
-        case key
-        when "home.welcome" then "Welcome to our lovely place!"
-        else fallback
+        def tuesday?
+          false
+        end
+
+        def day?(name)
+          name == "monday"
+        end
+
+        def season?(name:)
+          name == "summer"
+        end
+
+        def hello
+          "hello"
+        end
+
+        def self.method_available?(name)
+          true
         end
       end
+    end
 
-      def summary(length = "long")
-        case length
-        when "long" then "This is a long summary"
-        when "short" then "This is a short summary"
+    it "compiles simple references" do
+      evaluate("monday?").should == true
+      evaluate("tuesday?").should == false
+    end
+
+    it "compiles references with a parameter" do
+      evaluate("day.monday?").should == true
+      evaluate("day.tuesday?").should == false
+    end
+
+    it "compiles references with attributes" do
+      evaluate("season? name=summer").should == true
+      evaluate("season? name=winter").should == false
+    end
+
+    it "fails if the reference is missing a question mark" do
+      expect { evaluate("hello") }.to raise_exception(Curly::Error)
+    end
+
+    def evaluate(reference, &block)
+      code = Curly::ReferenceCompiler.compile_conditional(presenter_class, reference)
+      presenter = presenter_class.new
+      context = double("context", presenter: presenter)
+
+      context.instance_eval(<<-RUBY)
+        def self.render
+          #{code}
         end
-      end
+      RUBY
 
-      def invalid(x, y)
-      end
-
-      def widget(size:, color: nil)
-        s = "Widget (#{size})"
-        s << " - #{color}" if color
-        s
-      end
-
-      def self.method_available?(name)
-        true
-      end
+      context.render(&block)
     end
   end
 
-  it "compiles parameterized references" do
-    evaluate("i18n.home.welcome").should == "Welcome to our lovely place!"
-  end
+  describe ".compile_reference" do
+    let(:presenter_class) do
+      Class.new do
+        def title
+          "Welcome!"
+        end
 
-  it "compiles optionally parameterized references" do
-    evaluate("summary").should == "This is a long summary"
-    evaluate("summary.short").should == "This is a short summary"
-  end
+        def i18n(key, fallback: nil)
+          case key
+          when "home.welcome" then "Welcome to our lovely place!"
+          else fallback
+          end
+        end
 
-  it "compiles references with attributes" do
-    evaluate("widget size=100px").should == "Widget (100px)"
-  end
+        def summary(length = "long")
+          case length
+          when "long" then "This is a long summary"
+          when "short" then "This is a short summary"
+          end
+        end
 
-  it "compiles references with optional attributes" do
-    evaluate("widget color=blue size=50px").should == "Widget (50px) - blue"
-  end
+        def invalid(x, y)
+        end
 
-  it "allows both parameter and attributes" do
-    evaluate("i18n.hello fallback=yolo").should == "yolo"
-  end
+        def widget(size:, color: nil)
+          s = "Widget (#{size})"
+          s << " - #{color}" if color
+          s
+        end
 
-  it "fails when an invalid attribute is used" do
-    expect { evaluate("i18n.foo extreme=true") }.to raise_exception(Curly::Error)
-  end
-
-  it "fails when a parameterized reference is missing a parameter" do
-    expect { evaluate("i18n") }.to raise_exception(Curly::Error)
-  end
-
-  it "fails when a reference is missing a required attribute" do
-    expect { evaluate("widget") }.to raise_exception(Curly::Error)
-  end
-
-  it "fails when a non-parameterized reference is passed a parameter" do
-    expect { evaluate("title.rugby") }.to raise_exception(Curly::Error)
-  end
-
-  it "fails when the method takes more than one argument" do
-    expect { evaluate("invalid") }.to raise_exception(Curly::Error)
-  end
-
-  def evaluate(reference, &block)
-    code = Curly::ReferenceCompiler.compile_reference(presenter_class, reference)
-    presenter = presenter_class.new
-    context = double("context", presenter: presenter)
-
-    context.instance_eval(<<-RUBY)
-      def self.render
-        #{code}
+        def self.method_available?(name)
+          true
+        end
       end
-    RUBY
+    end
 
-    context.render(&block)
+    it "compiles parameterized references" do
+      evaluate("i18n.home.welcome").should == "Welcome to our lovely place!"
+    end
+
+    it "compiles optionally parameterized references" do
+      evaluate("summary").should == "This is a long summary"
+      evaluate("summary.short").should == "This is a short summary"
+    end
+
+    it "compiles references with attributes" do
+      evaluate("widget size=100px").should == "Widget (100px)"
+    end
+
+    it "compiles references with optional attributes" do
+      evaluate("widget color=blue size=50px").should == "Widget (50px) - blue"
+    end
+
+    it "allows both parameter and attributes" do
+      evaluate("i18n.hello fallback=yolo").should == "yolo"
+    end
+
+    it "fails when an invalid attribute is used" do
+      expect { evaluate("i18n.foo extreme=true") }.to raise_exception(Curly::Error)
+    end
+
+    it "fails when a parameterized reference is missing a parameter" do
+      expect { evaluate("i18n") }.to raise_exception(Curly::Error)
+    end
+
+    it "fails when a reference is missing a required attribute" do
+      expect { evaluate("widget") }.to raise_exception(Curly::Error)
+    end
+
+    it "fails when a non-parameterized reference is passed a parameter" do
+      expect { evaluate("title.rugby") }.to raise_exception(Curly::Error)
+    end
+
+    it "fails when the method takes more than one argument" do
+      expect { evaluate("invalid") }.to raise_exception(Curly::Error)
+    end
+
+    def evaluate(reference, &block)
+      code = Curly::ReferenceCompiler.compile_reference(presenter_class, reference)
+      presenter = presenter_class.new
+      context = double("context", presenter: presenter)
+
+      context.instance_eval(<<-RUBY)
+        def self.render
+          #{code}
+        end
+      RUBY
+
+      context.render(&block)
+    end
   end
 end


### PR DESCRIPTION
Adding attributes to a conditional block reference would cause an exception to be raised.

The next step should be to not require the attributes be part of the closing tag.
