### PR TITLE
Use SortedSet instead of Set

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -193,9 +193,9 @@ module Curly
       # Returns a Set of String view paths.
       def dependencies
         # The base presenter doesn't have any dependencies.
-        return Set.new if self == Curly::Presenter
+        return SortedSet.new if self == Curly::Presenter
 
-        @dependencies ||= Set.new
+        @dependencies ||= SortedSet.new
         @dependencies.union(superclass.dependencies)
       end
 
@@ -205,7 +205,7 @@ module Curly
       #
       # Returns nothing.
       def depends_on(*dependencies)
-        @dependencies ||= Set.new
+        @dependencies ||= SortedSet.new
         @dependencies.merge(dependencies)
       end
 


### PR DESCRIPTION
`Set` are collections of unordered values with no duplicates.
So using `Set` doesn't guarantee that the order of the dependencies
is always the same, this might leads to issues in the cache layer
where we calculate an MD5 for the `cache_key` based on what
`#dependencies` returns.

cc: @dasch @ilkkao @jacobat 
