### PR TITLE
Make sure Rails 4.1 correctly autoloads presenter classes

### DIFF
--- a/lib/curly/template_handler.rb
+++ b/lib/curly/template_handler.rb
@@ -59,7 +59,7 @@ class Curly::TemplateHandler
         options = local_assigns
       end
 
-      presenter = #{presenter_class}.new(self, options.with_indifferent_access)
+      presenter = ::#{presenter_class}.new(self, options.with_indifferent_access)
       presenter.setup!
 
       @output_buffer = output_buffer || ActiveSupport::SafeBuffer.new


### PR DESCRIPTION
Rails 4.1 introduced a regresssion in the autoloading mechanism. The presenter classes were being looked up from within the ActionView namespace, which for some reason broke the autoloader. Adding `::` to the front of the constant name forces Ruby to look up from the root namespace instead.

Fixes #93.
