### PR TITLE
Allow presenters to present helpers

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -47,7 +47,11 @@ module Curly
       self.class.presented_names.each do |name|
         value = options.fetch(name) do
           default_values.fetch(name) do
-            raise ArgumentError.new("required identifier `#{name}` missing")
+            if @_context.respond_to?(name.to_sym)
+              @_context.send(name.to_sym)
+            else
+              raise ArgumentError.new("required identifier `#{name}` missing")
+            end
           end
         end
 

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -39,6 +39,13 @@ describe Curly::Presenter do
       presenter.clown.should == "Bubbles"
     end
 
+    it "sets the presented helpers as instance variables" do
+      allow(context).to receive(:champagne) { "Bollinger" }
+      presenter = FancyCircusPresenter.new(context, {})
+
+      presenter.champagne.should == "Bollinger"
+    end
+
     it "raises an exception if a required identifier is not specified" do
       expect {
         FancyCircusPresenter.new(context, {})


### PR DESCRIPTION
Controllers that hide their implementation but provide helper methods
to access resources can now be used with Curly. For example, using the decent_exposure gem, instance variables that Curly relies on are no longer available to the presenter. I have extended the initializer to include a test for a helper that matches the presented name if no matching value can be found in the options or default values. If the helper exists, it is called and the return value assigned to the named presenter. 
