### PR TITLE
Basic Introspection

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -188,6 +188,13 @@ module Curly
         end
       end
 
+      def presenter_for?(name)
+        presenter_for_name(name)
+        true
+      rescue NameError
+        false
+      end
+
       # Whether a component is available to templates rendered with the
       # presenter.
       #
@@ -213,6 +220,64 @@ module Curly
       def available_components
         methods = public_instance_methods - Curly::Presenter.public_instance_methods
         methods.map(&:to_s)
+      end
+
+      # Gives a description of the presenter.  Gives information about its
+      # components, and what parameters they are allowed.
+      #
+      # Returns a Hash.
+      def description
+        result = {}
+        components = result[:components] = []
+
+        available_components.each do |component|
+          data = { name: component,
+                   type: "",
+                   attributes: [],
+                   identifier: nil,
+                   block: false }
+
+          if component.end_with?("?")
+            data[:type] = "conditional"
+          elsif presenter_for?(component)
+            data[:type] = "context"
+          elsif presenter_for?(component.singularize)
+            data[:type] = "collection"
+          else
+            data[:type] = "value"
+          end
+
+          instance_method(component.intern).parameters.each do |param|
+            add = {}
+            add[:name] = param[1].to_s
+
+            case param[0]
+            when :keyreq
+              add[:required] = true
+            when :key
+              add[:required] = false
+            when :req
+              data[:identifier] = add
+              add[:required]    = true
+              add = nil
+            when :opt
+              data[:identifier] = add
+              add[:required]    = false
+              add = nil
+            when :block
+              data[:block] = add[:name]
+              add = nil
+            else
+              raise ArgumentError, "Unknown parameter #{param[0]}"
+            end
+
+            data[:attributes] << add if add
+          end
+
+          components << data
+        end
+
+        result
       end
 
       # The set of view paths that the presenter depends on.

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -13,6 +13,26 @@ describe Curly::Presenter do
     presents :elephant, default: "Dumbo"
 
     attr_reader :midget, :clown, :elephant
+
+    def alpha(name, age: 12)
+      name
+    end
+
+    def beta(test:, this: "thing")
+      test + this
+    end
+
+    def charlie(&test)
+    end
+
+    def delta?
+      false
+    end
+
+    def cats
+    end
+
+    class CatPresenter < Curly::Presenter; end
   end
 
   class FrenchCircusPresenter < CircusPresenter
@@ -109,6 +129,72 @@ describe Curly::Presenter do
 
     it "returns false if the method is not available" do
       CircusPresenter.component_available?("bear").should == false
+    end
+  end
+
+  describe ".description" do
+    it "gives a hash" do
+      CircusPresenter.description.should be_a Hash
+    end
+
+    it "describes the components" do
+      description = CircusPresenter.description
+
+      description[:components].should have(9).items
+      description[:components].should == [
+        { name: "midget",
+          type: "value",
+          attributes: [],
+          identifier: nil,
+          block: false },
+        { name: "clown",
+          type: "value",
+          attributes: [],
+          identifier: nil,
+          block: false },
+        { name: "elephant",
+          type: "value",
+          attributes: [],
+          identifier: nil,
+          block: false },
+
+        { name: "alpha",
+          type: "value",
+          attributes: [
+            { name: "age", required: false }],
+          identifier: { name: "name", required: true },
+          block: false },
+
+        { name: "beta",
+          type: "value",
+          attributes: [
+            { name: "test", required: true },
+            { name: "this", required: false }],
+          identifier: nil,
+          block: false },
+
+        { name: "charlie",
+          type: "value",
+          attributes: [],
+          identifier: nil,
+          block: "test" },
+
+        { name: "delta?",
+          type: "conditional",
+          attributes: [],
+          identifier: nil,
+          block: false },
+        { name: "cats",
+          type: "collection",
+          attributes: [],
+          identifier: nil,
+          block: false },
+        { name: "monkey",
+          type: "context",
+          attributes: [],
+          identifier: nil,
+          block: false }
+      ]
     end
   end
 


### PR DESCRIPTION
Adds `.description` to `Curly::Presenter`, as well as `.presenter_for?`.  Noice.  Fixes #105.

``` Ruby
{
  components: [
    { name: "midget",
      type: "value",
      attributes: [],
      identifier: nil,
      block: false },
    { name: "clown",
      type: "value",
      attributes: [],
      identifier: nil,
      block: false },
    { name: "elephant",
      type: "value",
      attributes: [],
      identifier: nil,
      block: false },

    { name: "alpha",
      type: "value",
      attributes: [
        { name: "age", required: false }],
      identifier: { name: "name", required: true },
      block: false },

    { name: "beta",
      type: "value",
      attributes: [
        { name: "test", required: true },
        { name: "this", required: false }],
      identifier: nil,
      block: false },

    { name: "charlie",
      type: "value",
      attributes: [],
      identifier: nil,
      block: "test" },

    { name: "delta?",
      type: "conditional",
      attributes: [],
      identifier: nil,
      block: false },
    { name: "cats",
      type: "collection",
      attributes: [],
      identifier: nil,
      block: false },
    { name: "monkey",
      type: "context",
      attributes: [],
      identifier: nil,
      block: false }
  ]
}
```
