### PR TITLE
Cache compiled templates

### DIFF
--- a/lib/curly/template_handler.rb
+++ b/lib/curly/template_handler.rb
@@ -50,7 +50,7 @@ class Curly::TemplateHandler
 
       raise Curly::PresenterNotFound.new(path) if presenter_class.nil?
 
-      source = Curly.compile(template.source, presenter_class)
+      source = source_for(template, presenter_class)
 
       <<-RUBY
       if local_assigns.empty?
@@ -71,6 +71,18 @@ class Curly::TemplateHandler
 
       @output_buffer
       RUBY
+    end
+
+    def source_for(template, presenter_class)
+      key = "#{template.identifier}_#{presenter_class}"
+      template_cache.fetch(key) do
+        source = Curly.compile(template.source, presenter_class)
+        template_cache[key] = source
+      end
+    end
+
+    def template_cache
+      @template_cache ||= {}
     end
 
     def instrument(template, &block)

--- a/spec/template_handler_spec.rb
+++ b/spec/template_handler_spec.rb
@@ -89,11 +89,12 @@ describe Curly::TemplateHandler do
     end
   end
 
-  let(:template) { double("template", virtual_path: "test") }
+  let(:template) { double("template", virtual_path: "test", identifier: "test_identifier") }
   let(:context) { context_class.new }
 
   before do
     stub_const("TestPresenter", presenter_class)
+    Curly::TemplateHandler.instance_eval { @template_cache = {} }
   end
 
   it "passes in the presenter context to the presenter class" do
@@ -122,6 +123,14 @@ describe Curly::TemplateHandler do
     template.stub(:source) { "{{foo}}" }
     output
     context.content_for(:foo).should == "bar"
+  end
+
+  it "caches the template source" do
+    template.stub(:source) { "{{foo}}" }
+    Curly::stub(:compile).with("{{foo}}", presenter_class) { "ActiveSupport::SafeBuffer.new" }
+    output
+    output
+    Curly.should have_received(:compile).once
   end
 
   context "caching" do


### PR DESCRIPTION
Currently Curly recompiles (i.e., generates the  rendering ruby code) each time `Curly::TemplateHandler.call` is invoked.
In pages/partials where the same curly partial is rendered many times (i.e., collections) this can be avoided and the same compiled template can be reused.

This PR adds a cache for compiled templates such that when a template has already been compiled the compilation step is skipped and the cached result is returned.
