### PR TITLE
Rails 4.2 is released

### DIFF
--- a/curly-templates.gemspec
+++ b/curly-templates.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.add_dependency("actionpack", [">= 3.1", "< 4.2"])
+  s.add_dependency("actionpack", [">= 3.1", "< 5.0"])
 
-  s.add_development_dependency("railties", [">= 3.1", "< 4.2"])
+  s.add_development_dependency("railties", [">= 3.1", "< 5.0"])
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec", "~> 2.12")
   s.add_development_dependency("genspec")


### PR DESCRIPTION
Curly have been working for me with 4.2.0.rc{1,2,3} so I assume that it works with new release. Next Rails release will be 5.0.0 so I've updated deps specification.
