### PR TITLE
Add #respond_to_missing? to Curly::Presenter

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -307,5 +307,10 @@ module Curly
     def method_missing(method, *args, &block)
       @_context.public_send(method, *args, &block)
     end
+
+    # Tells ruby (and developers) what methods we can accept.
+    def respond_to_missing?(method, include_private = false)
+      @_context.respond_to?(method, false)
+    end
   end
 end

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -56,6 +56,26 @@ describe Curly::Presenter do
     end
   end
 
+  describe "#method_missing" do
+    let(:context) { double("context") }
+    subject {
+      CircusPresenter.new(context,
+        midget: "Meek Harolson",
+        clown: "Bubbles")
+    }
+
+    it "delegates calls to the context" do
+      context.should receive(:undefined).once
+      subject.undefined
+    end
+
+    it "allows method calls on context-defined methods" do
+      context.should receive(:respond_to?).
+        with(:undefined, false).once.and_return(true)
+      subject.method(:undefined)
+    end
+  end
+
   describe ".presenter_for_path" do
     it "returns the presenter class for the given path" do
       presenter = double("presenter")


### PR DESCRIPTION
This allows ruby to correctly respond in both `#method` and `#respond_to?` calls.  See [this](http://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding).  I encountered this when I was playing around with the `*_path` methods that are defined by Rails; they're defined on the context, but not on the presenter, so attempting to do i.e. `method(:some_path)` would result in a `NameError`.