### PR TITLE
Maintain a stack of output buffers

### DIFF
--- a/spec/compiler/context_blocks_spec.rb
+++ b/spec/compiler/context_blocks_spec.rb
@@ -19,8 +19,18 @@ describe Curly::Compiler do
     Class.new(Curly::Presenter) do
       presents :form
 
-      def text
-        @form.upcase
+      def text_field(&block)
+        block.call(@form)
+      end
+    end
+  end
+
+  let(:inner_context_presenter_class) do
+    Class.new(Curly::Presenter) do
+      presents :text_field
+
+      def field
+        %(<input type="text" value="#{@text_field.upcase}">).html_safe
       end
     end
   end
@@ -30,10 +40,11 @@ describe Curly::Compiler do
 
   before do
     stub_const("FormPresenter", context_presenter_class)
+    stub_const("TextFieldPresenter", inner_context_presenter_class)
   end
 
   it "compiles context blocks" do
-    evaluate('{{@form}}{{text}}{{/form}}').should == '<form>YO</form>'
+    evaluate('{{@form}}{{@text_field}}{{field}}{{/text_field}}{{/form}}').should == '<form><input type="text" value="YO"></form>'
   end
 
   it "fails if the component is not a context block" do

--- a/spec/dummy/app/views/dashboards/new.html.curly
+++ b/spec/dummy/app/views/dashboards/new.html.curly
@@ -3,3 +3,5 @@
     <b>{{label}}</b> {{input}}
   {{/name_field}}
 {{/form}}
+
+<p>Thank you!</p>

--- a/spec/integration/context_blocks_spec.rb
+++ b/spec/integration/context_blocks_spec.rb
@@ -5,7 +5,7 @@ describe "Context blocks", type: :request do
   example "A context block" do
     get '/new'
 
-    response.body.should have_structure <<-HTML
+    response.body.should have_structure <<-HTML.strip_heredoc
       <html>
       <head>
         <title>Dummy app</title>
@@ -16,6 +16,8 @@ describe "Context blocks", type: :request do
           <b>Name</b> <input id="dashboard_name" name="dashboard[name]" type="text" value="test" />
         </div>
       </form>
+
+      <p>Thank you!</p>
       </body>
       </html>
     HTML


### PR DESCRIPTION
Weird errors started cropping up when context blocks were being nested. They were caused by Ruby shadowing the buffer variable, making some stuff disappear:

```ruby
# This is the base buffer
buffer = ActiveSupport::SafeBuffer.new
buffer << "one"

# Let's render a context! We'll need a new buffer for that.
old_buffer, buffer = buffer, ActiveSupport::SafeBuffer.new
old_buffer << begin
  buffer << "two"

  # Let's render a nested context! One more buffer!
  old_buffer, buffer = buffer, ActiveSupport::SafeBuffer.new # This shadows old_buffer
  old_buffer << begin
    buffer << "three"
  end
  # close the nested context
  buffer = old_buffer
end
#close the outer context
buffer = old_buffer # notice that this is not the old_buffer saved by the outer context

buffer.to_s #=> "twothree"

# Uh oh! we lost some content!
```

In order to make things more reliable, a stack of buffers is employed. This allows us to restore the previous buffer by simply popping it off the stack.