### PR TITLE
Don't include extra whitespace in compiled text

### DIFF
--- a/lib/curly/compiler.rb
+++ b/lib/curly/compiler.rb
@@ -179,7 +179,9 @@ module Curly
     end
 
     def compile_text(text)
-      output "buffer.safe_concat(#{text.value.inspect})"
+      if non_whitespace_text = text.value.presence
+        output "buffer.safe_concat(#{non_whitespace_text.inspect})"
+      end
     end
 
     def compile_comment(comment)

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -130,6 +130,13 @@ describe Curly::Compiler do
       evaluate("test{{^false?}}bar{{/false?}}").should == "testbar"
     end
 
+    it "removes extra whitespace from the output" do
+      presenter.stub(:foo) { "" }
+      template = "{{^false?}}\n{{foo}}\n<a href='bar'>bar</a>\n{{foo}}\n{{/false?}}\n"
+
+      evaluate(template).should == "\n<a href='bar'>bar</a>\n"
+    end
+
     it "passes an argument to blocks" do
       evaluate("{{#hello.world?}}foo{{/hello.world?}}{{#hello.foo?}}bar{{/hello.foo?}}").should == "foo"
     end


### PR DESCRIPTION
Currently Curly ends up adding extra newlines after components like conditional or context block tags, which can make the resulting markup hard to read.

With this PR the following output:

```
<section class="knowledge-base">
  
  <div class="category-tree">
    
      <section class="category">
        

        
          
            <section class="section">
```

is shortened to:

```
<section class="knowledge-base">
  
  <div class="category-tree">
    
      <section class="category">
        
            <section class="section">
```

Alternatively Curly could strip text output altogether, but that may make the markup unreadable for lack of whitespace.

/cc @dasch