### PR TITLE
Add a shorthand syntax for components inside contexts

### DIFF
--- a/lib/curly/component_scanner.rb
+++ b/lib/curly/component_scanner.rb
@@ -4,7 +4,10 @@ module Curly
   class ComponentScanner
     def self.scan(component)
       first, rest = component.strip.split(/\s+/, 2)
-      name, identifier = first.split(".", 2)
+      contexts = first.split(":")
+      name_and_identifier = contexts.pop
+
+      name, identifier = name_and_identifier.split(".", 2)
 
       if identifier && identifier.end_with?("?")
         name += "?"
@@ -13,7 +16,7 @@ module Curly
 
       attributes = AttributeScanner.scan(rest)
 
-      [name, identifier, attributes]
+      [name, identifier, attributes, contexts]
     end
   end
 end

--- a/lib/curly/scanner.rb
+++ b/lib/curly/scanner.rb
@@ -95,45 +95,45 @@ module Curly
 
     def scan_conditional_block_start
       if value = scan_until_end_of_curly
-        name, identifier, attributes = ComponentScanner.scan(value)
+        name, identifier, attributes, contexts = ComponentScanner.scan(value)
 
-        [:conditional_block_start, name, identifier, attributes]
+        [:conditional_block_start, name, identifier, attributes, contexts]
       end
     end
 
     def scan_context_block_start
       if value = scan_until_end_of_curly
-        name, identifier, attributes = ComponentScanner.scan(value)
+        name, identifier, attributes, contexts = ComponentScanner.scan(value)
 
-        [:context_block_start, name, identifier, attributes]
+        [:context_block_start, name, identifier, attributes, contexts]
       end
     end
 
     def scan_collection_block_start
       if value = scan_until_end_of_curly
-        name, identifier, attributes = ComponentScanner.scan(value)
-        [:collection_block_start, name, identifier, attributes]
+        name, identifier, attributes, contexts = ComponentScanner.scan(value)
+        [:collection_block_start, name, identifier, attributes, contexts]
       end
     end
 
     def scan_inverse_block_start
       if value = scan_until_end_of_curly
-        name, identifier, attributes = ComponentScanner.scan(value)
-        [:inverse_conditional_block_start, name, identifier, attributes]
+        name, identifier, attributes, contexts = ComponentScanner.scan(value)
+        [:inverse_conditional_block_start, name, identifier, attributes, contexts]
       end
     end
 
     def scan_block_end
       if value = scan_until_end_of_curly
-        name, identifier, attributes = ComponentScanner.scan(value)
-        [:block_end, name, identifier]
+        name, identifier, attributes, contexts = ComponentScanner.scan(value)
+        [:block_end, name, identifier, {}, contexts]
       end
     end
 
     def scan_component
       if value = scan_until_end_of_curly
-        name, identifier, attributes = ComponentScanner.scan(value)
-        [:component, name, identifier, attributes]
+        name, identifier, attributes, contexts = ComponentScanner.scan(value)
+        [:component, name, identifier, attributes, contexts]
       end
     end
 

--- a/spec/compiler/context_blocks_spec.rb
+++ b/spec/compiler/context_blocks_spec.rb
@@ -22,6 +22,10 @@ describe Curly::Compiler do
       def field
         %(<input type="text" value="#{@text_field.upcase}">).html_safe
       end
+
+      def value?
+        true
+      end
     end
 
     render('{{@form}}{{@text_field}}{{field}}{{/text_field}}{{/form}}').should == '<form><input type="text" value="YO"></form>'
@@ -47,5 +51,37 @@ describe Curly::Compiler do
     expect {
       render('{{@dust}}{{/dust}}')
     }.to raise_exception(Curly::Error)
+  end
+
+  it "fails if the component is not a context block" do
+    expect { render('{{@invalid}}yo{{/invalid}}') }.to raise_exception(Curly::Error)
+  end
+
+  it "compiles shorthand context components" do
+    define_presenter do
+      def tree(&block)
+        yield
+      end
+    end
+
+    define_presenter "TreePresenter" do
+      def branch(&block)
+        yield
+      end
+    end
+
+    define_presenter "BranchPresenter" do
+      def leaf
+        "leaf"
+      end
+    end
+
+    render('{{tree:branch:leaf}}').should == "leaf"
+  end
+
+  it "requires shorthand blocks to be closed with the same set of namespaces" do
+    expect do
+      render('{{#tree:branch}}{{/branch}}{{/tree}}')
+    end.to raise_exception(Curly::IncorrectEndingError)
   end
 end

--- a/spec/component_scanner_spec.rb
+++ b/spec/component_scanner_spec.rb
@@ -3,19 +3,30 @@ describe Curly::ComponentScanner do
     scan('hello.world weather="sunny"').should == [
       "hello",
       "world",
-      { "weather" => "sunny" }
+      { "weather" => "sunny" },
+      []
+    ]
+  end
+
+  it "allows context namespaces" do
+    scan('island:beach:hello.world').should == [
+      "hello",
+      "world",
+      {},
+      ["island", "beach"]
     ]
   end
 
   it "allows a question mark after the identifier" do
-    scan('hello.world?').should == ["hello?", "world", {}]
+    scan('hello.world?').should == ["hello?", "world", {}, []]
   end
 
   it 'allows spaces before and after component' do
     scan('  hello.world weather="sunny"   ').should == [
       "hello",
       "world",
-      { "weather" => "sunny" }
+      { "weather" => "sunny" },
+      []
     ]
   end
 

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -2,14 +2,14 @@ describe Curly::Scanner, ".scan" do
   it "returns the tokens in the source" do
     scan("foo {{bar}} baz").should == [
       [:text, "foo "],
-      [:component, "bar", nil, {}],
+      [:component, "bar", nil, {}, []],
       [:text, " baz"]
     ]
   end
 
   it "scans components with identifiers" do
     scan("{{foo.bar}}").should == [
-      [:component, "foo", "bar", {}]
+      [:component, "foo", "bar", {}, []]
     ]
   end
 
@@ -53,44 +53,44 @@ describe Curly::Scanner, ".scan" do
 
   it "scans context block tags" do
     scan('{{@search_form}}{{query_field}}{{/search_form}}').should == [
-      [:context_block_start, "search_form", nil, {}],
-      [:component, "query_field", nil, {}],
-      [:block_end, "search_form", nil]
+      [:context_block_start, "search_form", nil, {}, []],
+      [:component, "query_field", nil, {}, []],
+      [:block_end, "search_form", nil, {}, []]
     ]
   end
 
   it "scans conditional block tags" do
     scan('foo {{#bar?}} hello {{/bar?}}').should == [
       [:text, "foo "],
-      [:conditional_block_start, "bar?", nil, {}],
+      [:conditional_block_start, "bar?", nil, {}, []],
       [:text, " hello "],
-      [:block_end, "bar?", nil]
+      [:block_end, "bar?", nil, {}, []]
     ]
   end
 
   it "scans conditional block tags with parameters and attributes" do
     scan('{{#active.test? name="test"}}yo{{/active.test?}}').should == [
-      [:conditional_block_start, "active?", "test", { "name" => "test" }],
+      [:conditional_block_start, "active?", "test", { "name" => "test" }, []],
       [:text, "yo"],
-      [:block_end, "active?", "test"]
+      [:block_end, "active?", "test", {}, []]
     ]
   end
 
   it "scans inverse block tags" do
     scan('foo {{^bar?}} hello {{/bar?}}').should == [
       [:text, "foo "],
-      [:inverse_conditional_block_start, "bar?", nil, {}],
+      [:inverse_conditional_block_start, "bar?", nil, {}, []],
       [:text, " hello "],
-      [:block_end, "bar?", nil]
+      [:block_end, "bar?", nil, {}, []]
     ]
   end
 
   it "scans collection block tags" do
     scan('foo {{*bar}} hello {{/bar}}').should == [
       [:text, "foo "],
-      [:collection_block_start, "bar", nil, {}],
+      [:collection_block_start, "bar", nil, {}, []],
       [:text, " hello "],
-      [:block_end, "bar", nil]
+      [:block_end, "bar", nil, {}, []]
     ]
   end
 


### PR DESCRIPTION
**EXPERIMENTAL**

Rather than `{{@author}}{{name}}{{/author}}` it's now possible to write `{{author:name}}`. I'm not sure this is something we want, even if it makes accessing stuff in context blocks easier.

- Multiple levels are allowed, e.g. `{{post:author:name}}`.
- Works for all component types, including blocks, e.g. `{{#post:author:admin?}} ... {{/post:author:admin?}}`.
- ~~Works by modifying the parse tree, so this is valid: `{{#post:author:admin?}} ... {{/author:admin?}}{{/post}}`. I'm not sure that's a good idea, though. Alternatively, the parse tree would hold the namespace and the compiler would unfold it into the tree structure.~~