### PR TITLE
Clean up the compiler specs

### DIFF
--- a/spec/compiler/context_blocks_spec.rb
+++ b/spec/compiler/context_blocks_spec.rb
@@ -35,19 +35,51 @@ describe Curly::Compiler do
     end
   end
 
-  let(:context) { double("context") }
-  let(:presenter) { presenter_class.new(context, {}) }
-
-  before do
-    stub_const("FormPresenter", context_presenter_class)
-    stub_const("TextFieldPresenter", inner_context_presenter_class)
-  end
-
   it "compiles context blocks" do
-    evaluate('{{@form}}{{@text_field}}{{field}}{{/text_field}}{{/form}}').should == '<form><input type="text" value="YO"></form>'
+    define_presenter do
+      def form(&block)
+        "<form>".html_safe + block.call("yo") + "</form>".html_safe
+      end
+    end
+
+    define_presenter "FormPresenter" do
+      presents :form
+
+      def text_field(&block)
+        block.call(@form)
+      end
+    end
+
+    define_presenter "TextFieldPresenter" do
+      presents :text_field
+
+      def field
+        %(<input type="text" value="#{@text_field.upcase}">).html_safe
+      end
+    end
+
+    render('{{@form}}{{@text_field}}{{field}}{{/text_field}}{{/form}}').should == '<form><input type="text" value="YO"></form>'
   end
 
   it "fails if the component is not a context block" do
-    expect { evaluate('{{@invalid}}yo{{/invalid}}') }.to raise_exception(Curly::Error)
+    define_presenter do
+      def form
+      end
+    end
+
+    expect {
+      render('{{@form}}{{/form}}')
+    }.to raise_exception(Curly::Error)
+  end
+
+  it "fails if the component doesn't match a presenter class" do
+    define_presenter do
+      def dust(&block)
+      end
+    end
+
+    expect {
+      render('{{@dust}}{{/dust}}')
+    }.to raise_exception(Curly::Error)
   end
 end


### PR DESCRIPTION
Allow defining the presenters inline in the examples. This allows the presenters to concern themselves only with the needs of a single example.