### PR TITLE
Add .exposes_helper to Presenter

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -292,6 +292,16 @@ module Curly
           self.default_values = self.default_values.merge(default_values)
         end
       end
+
+      def exposes_helper(*methods)
+        methods.each do |method_name|
+          define_method(method_name) do |*args|
+            @_context.public_send(method_name, *args)
+          end
+        end
+      end
+
+      alias_method :exposes_helpers, :exposes_helper
     end
 
     private

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -5,6 +5,8 @@ describe Curly::Presenter do
       end
     end
 
+    exposes_helper :foo
+
     include MonkeyComponents
 
     presents :midget, :clown, default: nil
@@ -71,6 +73,29 @@ describe Curly::Presenter do
       context.should receive(:respond_to?).
         with(:undefined, false).once.and_return(true)
       subject.method(:undefined)
+    end
+  end
+
+  describe ".exposes_helper" do
+    let(:context) { double("context") }
+    subject {
+      CircusPresenter.new(context,
+        midget: "Meek Harolson",
+        clown: "Bubbles")
+    }
+
+    it "allows a method as a component" do
+      CircusPresenter.component_available?(:foo)
+    end
+
+    it "delegates the call to the context" do
+      context.should receive(:foo).once
+      subject.should_not receive(:method_missing)
+      subject.foo
+    end
+
+    it "doesn't delegate other calls to the context" do
+      expect { subject.bar }.to raise_error
     end
   end
 


### PR DESCRIPTION
This allows delegation of some methods, i.e. root_path, to the context.  It essentially defines a method on the presenter to allow passing the method directly to the context.  This not only allows the method call to bypass the #method_missing method, it also removes boilerplate code for some methods.

An example, in rails:

```Ruby
class Article::ShowPresenter < Curly::Presenter
  presents :article

  # ...

  context_method :root_path
end
```

```HTML
<!-- views/articles/show.html.curly -->

<span class="home-path">{{root_path}}</span>
```