### PR TITLE
Fix Constant Search

### DIFF
--- a/lib/curly/compiler.rb
+++ b/lib/curly/compiler.rb
@@ -107,7 +107,7 @@ module Curly
         items = Array(#{method_call})
         items.each_with_index do |item, index|
           options = options.merge("#{name}" => item, "#{counter}" => index + 1)
-          presenter = #{item_presenter_class}.new(self, options)
+          presenter = ::#{item_presenter_class}.new(self, options)
       RUBY
 
       @presenter_classes.push(item_presenter_class)
@@ -160,7 +160,7 @@ module Curly
         buffer << #{method_call} do |item|
           options = options.merge("#{name}" => item)
           buffer = ActiveSupport::SafeBuffer.new
-          presenter = #{item_presenter_class}.new(self, options)
+          presenter = ::#{item_presenter_class}.new(self, options)
       RUBY
 
       @presenter_classes.push(item_presenter_class)

--- a/spec/compiler/context_blocks_spec.rb
+++ b/spec/compiler/context_blocks_spec.rb
@@ -27,6 +27,25 @@ describe Curly::Compiler do
     render('{{@form}}{{@text_field}}{{field}}{{/text_field}}{{/form}}').should == '<form><input type="text" value="YO"></form>'
   end
 
+  it "compiles using the right presenter" do
+    define_presenter "Layouts::SomePresenter" do
+
+      def contents(&block)
+        block.call("hello, world")
+      end
+    end
+
+    define_presenter "Layouts::SomePresenter::ContentsPresenter" do
+      presents :contents
+
+      def contents
+        @contents
+      end
+    end
+
+    render("foo: {{@contents}}{{contents}}{{/contents}}", presenter: "Layouts::SomePresenter").should == 'foo: hello, world'
+  end
+
   it "fails if the component is not a context block" do
     define_presenter do
       def form

--- a/spec/dummy/app/presenters/layouts/application_presenter.rb
+++ b/spec/dummy/app/presenters/layouts/application_presenter.rb
@@ -6,4 +6,16 @@ class Layouts::ApplicationPresenter < Curly::Presenter
   def content
     yield
   end
+
+  def header(&block)
+    block.call
+  end
+
+  class HeaderPresenter < Curly::Presenter
+
+    def title
+      "Dummy app"
+    end
+  end
+
 end

--- a/spec/dummy/app/views/layouts/application.html.curly
+++ b/spec/dummy/app/views/layouts/application.html.curly
@@ -3,6 +3,9 @@
   <title>{{title}}</title>
 </head>
 <body>
+{{@header}}<header>
+  <h1>{{title}}</h1>
+</header>{{/header}}
 {{content}}
 </body>
 </html>

--- a/spec/integration/application_layout_spec.rb
+++ b/spec/integration/application_layout_spec.rb
@@ -8,6 +8,9 @@ describe "Using Curly for the application layout", type: :request do
         <title>Dummy app</title>
       </head>
       <body>
+      <header>
+        <h1>Dummy app</h1>
+      </header>
       <h1>Dashboard</h1>
       <p>Hello, World!</p>
       <p>Welcome!</p>

--- a/spec/integration/collection_blocks_spec.rb
+++ b/spec/integration/collection_blocks_spec.rb
@@ -8,6 +8,9 @@ describe "Collection blocks", type: :request do
         <title>Dummy app</title>
       </head>
       <body>
+      <header>
+        <h1>Dummy app</h1>
+      </header>
       <ul>
 
         <li>uno</li>

--- a/spec/integration/context_blocks_spec.rb
+++ b/spec/integration/context_blocks_spec.rb
@@ -10,6 +10,9 @@ describe "Context blocks", type: :request do
         <title>Dummy app</title>
       </head>
       <body>
+      <header>
+        <h1>Dummy app</h1>
+      </header>
       <form accept-charset="UTF-8" action="/new" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="field">
           <b>Name</b> <input id="dashboard_name" name="dashboard[name]" type="text" value="test" />

--- a/spec/integration/partials_spec.rb
+++ b/spec/integration/partials_spec.rb
@@ -8,6 +8,9 @@ describe "Using Curly for Rails partials", type: :request do
         <title>Dummy app</title>
       </head>
       <body>
+      <header>
+        <h1>Dummy app</h1>
+      </header>
       <ul>
         <li>One (yo)</li>
         <li>Two (yo)</li>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,23 +14,30 @@ module CompilationSupport
     presenter_class
   end
 
-  def render(source, locals = {}, presenter_class = nil, &block)
-    if presenter_class.nil?
-      unless defined?(ShowPresenter)
-        define_presenter("ShowPresenter")
-      end
+  def render(source, options = {}, &block)
+    presenter = options.fetch(:presenter) do
+      define_presenter("ShowPresenter") unless defined?(ShowPresenter)
+      "ShowPresenter"
+    end.constantize
 
-      presenter_class = ShowPresenter
+    virtual_path = options.fetch(:virtual_path) do
+      presenter.name.underscore.gsub(/_presenter\z/, "")
     end
 
-    identifier = "show"
+    identifier = options.fetch(:identifier) do
+      defined?(Rails.root) ? "#{Rails.root}/#{virtual_path}.html.curly" : virtual_path
+    end
+
+    details = { virtual_path: virtual_path }
+    details.merge! options.fetch(:details, {})
+
     handler = Curly::TemplateHandler
-    details = { virtual_path: 'show' }
     template = ActionView::Template.new(source, identifier, handler, details)
     view = ActionView::Base.new
+    view.lookup_context.stub(:find_template) { source }
 
     begin
-      template.render(view, locals, &block)
+      template.render(view, options.fetch(:locals, {}), &block)
     rescue ActionView::Template::Error => e
       raise e.original_exception
     end


### PR DESCRIPTION
If a context or collection constant presenter is named with a name that conflicts with any constant within the `ActionView` scope, the constant from ActionView would prevail; this is a problem, because then you end up with things like `ActionView::Layouts::SomePresenter`, which doesn't exist, being referenced from within the compiled template.

For example:

```Ruby
class Layouts::ApplicationPresenter

  def header(&block)
    block.call
  end

   class HeaderPresenter
   end
end
```

This would error.  On a side note, I modified `CompilationSupport#render` to allow specification of a presenter, and other things.  A side effect of this is that you must pass locals in as a keyword pair; i.e. `locals: { foo: :bar }`.