### PR TITLE
Delegate :render to :@_context

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -311,6 +311,8 @@ module Curly
     self.presented_names = [].freeze
     self.default_values = {}.freeze
 
+    delegate :render, to: :@_context
+
     # Delegates private method calls to the current view context.
     #
     # The view context, an instance of ActionView::Base, is set by Rails.


### PR DESCRIPTION
There's no need for this call to go through `#method_missing`.

Also I an currently profiling all calls to `#method_missing`, and I would like *not* to profile the `#render` calls.