### PR TITLE
Consolidating entry point for presenter retrieval

### DIFF
--- a/lib/curly/compiler.rb
+++ b/lib/curly/compiler.rb
@@ -94,12 +94,7 @@ module Curly
       name = component.name.singularize
       counter = "#{name}_counter"
 
-      begin
-        item_presenter_class = presenter_class.presenter_for_name(name)
-      rescue NameError
-        raise Curly::Error,
-          "cannot enumerate `#{name}`, could not find matching presenter class"
-      end
+      item_presenter_class = presenter_class.presenter_for_name(name)
 
       output <<-RUBY
         presenters << presenter
@@ -146,12 +141,7 @@ module Curly
 
       name = component.name
 
-      begin
-        item_presenter_class = presenter_class.presenter_for_name(name)
-      rescue NameError
-        raise Curly::Error,
-          "cannot use context `#{name}`, could not find matching presenter class"
-      end
+      item_presenter_class = presenter_class.presenter_for_name(name)
 
       output <<-RUBY
         options_stack << options

--- a/lib/curly/presenter_name_error.rb
+++ b/lib/curly/presenter_name_error.rb
@@ -1,0 +1,16 @@
+require 'curly/error'
+
+module Curly
+  class PresenterNameError < Error
+    attr_reader :original_exception, :name
+
+    def initialize(original_exception, name)
+      @name = name
+      @original_exception = original_exception
+    end
+
+    def message
+      "cannot use context `#{name}`, could not find matching presenter class"
+    end
+  end
+end


### PR DESCRIPTION
Instead of relying on two separate bits of logic for presenter
retrieval; One by path and one by class name, leverage the same logic.

In doing this, I am also able to leverage nested lookups as per the
documentation.

Closes #144