### PR TITLE
Add Support for :keyrest arguments

### DIFF
--- a/lib/curly/component_compiler.rb
+++ b/lib/curly/component_compiler.rb
@@ -64,8 +64,7 @@ module Curly
     end
 
     def invalid_signature?
-      positional_params = param_types.select {|type| [:req, :opt].include?(type) }
-      positional_params.size > 1
+      param_types.count { |type| [:req, :opt].include?(type) } > 1
     end
 
     def required_identifier?
@@ -89,7 +88,7 @@ module Curly
     end
 
     def validate_attributes!
-      attributes.keys.each do |key|
+      attributes_collected? || attributes.keys.each do |key|
         unless attribute_names.include?(key)
           raise Curly::Error, "`#{method}` does not allow attribute `#{key}`"
         end
@@ -114,6 +113,10 @@ module Curly
       @attribute_names ||= params.
         select {|type, name| [:key, :keyreq].include?(type) }.
         map {|type, name| name.to_s }
+    end
+
+    def attributes_collected?
+      param_types.include?(:keyrest)
     end
 
     def required_attribute_names

--- a/spec/component_compiler_spec.rb
+++ b/spec/component_compiler_spec.rb
@@ -13,6 +13,10 @@ describe Curly::ComponentCompiler do
           end
         end
 
+        def collected(**options)
+          options.to_a.map { |(k, v)| "#{k}: #{v}" }.join("\n")
+        end
+
         def summary(length = "long")
           case length
           when "long" then "This is a long summary"
@@ -50,6 +54,10 @@ describe Curly::ComponentCompiler do
 
     it "compiles components with attributes" do
       evaluate("widget size=100px").should == "Widget (100px)"
+    end
+
+    it "compiles components with collected attributes" do
+      evaluate("collected class=test for=you").should == "class: test\nfor: you"
     end
 
     it "compiles components with optional attributes" do


### PR DESCRIPTION
Currently, curly does not support this:

```ruby
def component(**options)
end
```

However, this patch should allow curly to accept and handle these options.  Proper tests are added.