### PR TITLE
Add extra check in the presenter class resolution

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -185,6 +185,7 @@ module Curly
           full_name = namespace.join("::") << "::" << class_name
           const_get(full_name)
         rescue NameError => e
+          raise unless e.class == NameError
           if namespace.empty?
             raise Curly::PresenterNameError.new(e, name)
           end


### PR DESCRIPTION
There are a few subclasses of `NameError` in which `rescue NameError`
also qualifies; namely, `NoMethodError` also qualifies as a `NameError`,
and as such, would trigger the rescue block incorrectly.  Since any
class can subclass `NameError`, the only real option is to raise if
the error isn't an instance of `NameError`.

I ran into this issue while creating a presenter - I had incorrectly typed a
class method, and as such, it raised a `NoMethodError`, and was handled
oddly by Curly.  This should prevent that issue from happening, but I'm not
sure how to test it.