### PR TITLE
Use constantize rather than get_const

### DIFF
--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -183,7 +183,7 @@ module Curly
         # solution in the future.
         begin
           full_name = namespace.join("::") << "::" << class_name
-          const_get(full_name)
+          full_name.constantize
         rescue NameError => e
           # Due to the way the exception hirearchy works, we need to check
           # that this exception is actually a `NameError` - since other

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -141,11 +141,11 @@ describe Curly::Presenter do
 
   describe ".presenter_for_name" do
     it 'looks through the container namespaces' do
-      PresenterContainer::PresenterSubcontainer::SubNestedPresenter.presenter_for_name('nested') == PresenterContainer::NestedPresenter
+      PresenterContainer::PresenterSubcontainer::SubNestedPresenter.presenter_for_name('nested').should == PresenterContainer::NestedPresenter
     end
 
     it 'looks through the container namespaces' do
-      Curly::Presenter.presenter_for_name('presenter_container/presenter_subcontainer/nested', []) == PresenterContainer::NestedPresenter
+      Curly::Presenter.presenter_for_name('presenter_container/presenter_subcontainer/nested', []).should == (PresenterContainer::NestedPresenter)
     end
 
     it "returns the presenter class for the given name" do

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -145,7 +145,7 @@ describe Curly::Presenter do
     end
 
     it 'looks through the container namespaces' do
-      Curly::Presenter.presenter_for_name('presenter_container/presenter_subcontainer/nested') == PresenterContainer::NestedPresenter
+      Curly::Presenter.presenter_for_name('presenter_container/presenter_subcontainer/nested', []) == PresenterContainer::NestedPresenter
     end
 
     it "returns the presenter class for the given name" do


### PR DESCRIPTION
This PR is in response to some errors I was getting when running HC locally in Docker (mentioned [here](https://zendesk.slack.com/archives/help-center-dev/p1467925456000063) and [here](https://zendesk.slack.com/archives/help-center-dev/p1468269100000048)). They related to multiple different `Admin` presenters and all had this general form:

```
Curly::PresenterNotFound at /hc/admin/categories/new
error compiling 'admin/translations/_select_source': could not find Admin::Translations::SelectSourcePresenter
```

After a good amount of digging, I discovered that v2.5.0 of this gem worked fine, and that cherry-picking #145 caused the issue to return. I eventually narrowed it down to `const_get` seeing these paths as uninitialized constants. `constantize`, however, seems to resolve the issue.

cc: @dasch @bquorning