### PR TITLE
DependencyTracker.call must return Array

### DIFF
--- a/lib/curly/dependency_tracker.rb
+++ b/lib/curly/dependency_tracker.rb
@@ -2,7 +2,7 @@ module Curly
   class DependencyTracker
     def self.call(path, template)
       presenter = Curly::Presenter.presenter_for_path(path)
-      presenter.dependencies
+      presenter.dependencies.to_a
     end
   end
 end


### PR DESCRIPTION
Rails (since 5.0.0) will eventually call `uniq` on it:
https://github.com/rails/rails/blob/v5.0.0/actionview/lib/action_view/digestor.rb#L54-L55