### PR TITLE
Fix scaffold generator having static string.

### DIFF
--- a/lib/generators/curly/scaffold/templates/form_presenter.rb.erb
+++ b/lib/generators/curly/scaffold/templates/form_presenter.rb.erb
@@ -9,8 +9,8 @@ class <%= plural_table_name.capitalize %>::<%= @view_name.capitalize %>Presenter
   # idempotent.
   presents :<%= singular_table_name %>
 
-  def post_errors
-    @post.errors
+  def <%= singular_table_name %>_errors
+    @<%= singular_table_name %>.errors
   end
 
   def <%= singular_table_name %>
@@ -25,7 +25,7 @@ class <%= plural_table_name.capitalize %>::<%= @view_name.capitalize %>Presenter
     presents :<%= singular_table_name %>_form, :<%= singular_table_name %>
 
     def <%= singular_table_name %>_errors(&block)
-      block.call(@post.errors)
+      block.call(@<%= singular_table_name %>.errors)
     end
 
     def label(field_name)

--- a/spec/generators/scaffold_curly_generator_spec.rb
+++ b/spec/generators/scaffold_curly_generator_spec.rb
@@ -2,14 +2,14 @@ require 'genspec'
 require 'generators/curly/scaffold/scaffold_generator'
 
 describe Curly::Generators::ScaffoldGenerator do
-  with_args %w(post title body published:boolean)
+  with_args %w(article title body published:boolean)
 
   it "generates an Curly template for the index view" do
-    expect(subject).to generate("app/views/posts/index.html.curly") {|content|
+    expect(subject).to generate("app/views/articles/index.html.curly") {|content|
       expect(content).to include "<th>Body</th>"
       expect(content).to include "<th>Title</th>"
       expect(content).to include "<th>Published</th>"
-      expect(content).to include "{{*posts}}"
+      expect(content).to include "{{*articles}}"
       # Consistantly not have spaces between curlys.
       expect(content).to include "{{show_link}}"
       expect(content).to include "{{edit_link}}"
@@ -21,33 +21,33 @@ describe Curly::Generators::ScaffoldGenerator do
     }
   end
   it "generates an Curly template for the show view" do
-    expect(subject).to generate("app/views/posts/show.html.curly") {|content|
-      expect(content).to include "{{*post}}"
+    expect(subject).to generate("app/views/articles/show.html.curly") {|content|
+      expect(content).to include "{{*article}}"
       expect(content).to include "<strong>Title:</strong>"
       expect(content).to include "{{title}}"
       expect(content).to include "<strong>Body:</strong>"
       expect(content).to include "{{body}}"
       expect(content).to include "<strong>Published:</strong>"
       expect(content).to include "{{published}}"
-      expect(content).to include "{{posts_link}}"
+      expect(content).to include "{{articles_link}}"
     }
   end
   it "generates an Curly template for the new view" do
-    expect(subject).to generate("app/views/posts/new.html.curly") {|content|
-      expect(content).to include "<h1>New Post</h1>"
-      expect(content).to include "{{post_form}}"
+    expect(subject).to generate("app/views/articles/new.html.curly") {|content|
+      expect(content).to include "<h1>New Article</h1>"
+      expect(content).to include "{{article_form}}"
     }
   end
   it "generates an Curly template for the edit view" do
-    expect(subject).to generate("app/views/posts/edit.html.curly") {|content|
-      expect(content).to include "<h1>Editing Post</h1>"
-      expect(content).to include "{{post_form}}"
+    expect(subject).to generate("app/views/articles/edit.html.curly") {|content|
+      expect(content).to include "<h1>Editing Article</h1>"
+      expect(content).to include "{{article_form}}"
     }
   end
   it "generates an Curly template for the form view" do
-    expect(subject).to generate("app/views/posts/_form.html.curly") {|content|
-      expect(content).to include "{{@post_form}}"
-      expect(content).to include "{{#post_errors:any?}}"
+    expect(subject).to generate("app/views/articles/_form.html.curly") {|content|
+      expect(content).to include "{{@article_form}}"
+      expect(content).to include "{{#article_errors:any?}}"
       expect(content).to include "{{label.title}}"
       expect(content).to include "{{label.body}}"
       expect(content).to include "{{label.published}}"

--- a/spec/generators/scaffold_presenter_generator_spec.rb
+++ b/spec/generators/scaffold_presenter_generator_spec.rb
@@ -2,63 +2,63 @@ require 'genspec'
 require 'generators/curly/scaffold/scaffold_generator'
 
 describe Curly::Generators::ScaffoldGenerator do
-  with_args %w(post title body published:boolean)
+  with_args %w(article title body published:boolean)
 
   it "generates a Curly presenter for the index view" do
-    expect(subject).to generate("app/presenters/posts/index_presenter.rb") {|content|
-      expect(content).to include "class Posts::IndexPresenter < Curly::Presenter" 
-      expect(content).to include "presents :posts" 
-      expect(content).to include "def posts" 
-      expect(content).to include "def notice_text" 
-      expect(content).to include "def create_link" 
-      expect(content).to include "class PostPresenter < Curly::Presenter" 
-      expect(content).to include "def title" 
-      expect(content).to include "def body" 
-      expect(content).to include "def published" 
+    expect(subject).to generate("app/presenters/articles/index_presenter.rb") {|content|
+      expect(content).to include "class Articles::IndexPresenter < Curly::Presenter"
+      expect(content).to include "presents :articles"
+      expect(content).to include "def articles"
+      expect(content).to include "def notice_text"
+      expect(content).to include "def create_link"
+      expect(content).to include "class ArticlePresenter < Curly::Presenter"
+      expect(content).to include "def title"
+      expect(content).to include "def body"
+      expect(content).to include "def published"
     }
   end
   it "generates a Curly presenter for the show view" do
-    expect(subject).to generate("app/presenters/posts/show_presenter.rb") {|content|
-      expect(content).to include "class Posts::ShowPresenter < Curly::Presenter" 
-      expect(content).to include "presents :post" 
-      expect(content).to include "def post" 
-      expect(content).to include "def notice_text" 
-      expect(content).to include "def posts_link" 
-      expect(content).to include "class PostPresenter < Curly::Presenter" 
-      expect(content).to include "def title" 
-      expect(content).to include "def body" 
-      expect(content).to include "def published" 
+    expect(subject).to generate("app/presenters/articles/show_presenter.rb") {|content|
+      expect(content).to include "class Articles::ShowPresenter < Curly::Presenter"
+      expect(content).to include "presents :article"
+      expect(content).to include "def article"
+      expect(content).to include "def notice_text"
+      expect(content).to include "def articles_link"
+      expect(content).to include "class ArticlePresenter < Curly::Presenter"
+      expect(content).to include "def title"
+      expect(content).to include "def body"
+      expect(content).to include "def published"
     }
   end
   it "generates a Curly presenter for the new view" do
-    expect(subject).to generate("app/presenters/posts/new_presenter.rb") {|content|
-      expect(content).to include "class Posts::NewPresenter < Curly::Presenter" 
-      expect(content).to include "presents :post" 
-      expect(content).to include "def post_form" 
-      expect(content).to include "render 'form', post: @post" 
-      expect(content).to include "def posts_link" 
+    expect(subject).to generate("app/presenters/articles/new_presenter.rb") {|content|
+      expect(content).to include "class Articles::NewPresenter < Curly::Presenter"
+      expect(content).to include "presents :article"
+      expect(content).to include "def article_form"
+      expect(content).to include "render 'form', article: @article"
+      expect(content).to include "def articles_link"
     }
   end
   it "generates a Curly presenter for the edit view" do
-    expect(subject).to generate("app/presenters/posts/edit_presenter.rb") {|content|
-      expect(content).to include "class Posts::EditPresenter < Curly::Presenter" 
-      expect(content).to include "presents :post" 
-      expect(content).to include "def post" 
-      expect(content).to include "def post_form" 
-      expect(content).to include "render 'form', post: @post" 
-      expect(content).to include "def posts_link" 
+    expect(subject).to generate("app/presenters/articles/edit_presenter.rb") {|content|
+      expect(content).to include "class Articles::EditPresenter < Curly::Presenter"
+      expect(content).to include "presents :article"
+      expect(content).to include "def article"
+      expect(content).to include "def article_form"
+      expect(content).to include "render 'form', article: @article"
+      expect(content).to include "def articles_link"
     }
   end
   it "generates a Curly presenter for the form view" do
-    expect(subject).to generate("app/presenters/posts/form_presenter.rb") {|content|
-      expect(content).to include "class Posts::FormPresenter < Curly::Presenter" 
-      expect(content).to include "presents :post" 
-      expect(content).to include "def post_errors" 
-      expect(content).to include "def post_form(&block)" 
-      expect(content).to include "def submit" 
-      expect(content).to include "class PostFormPresenter < Curly::Presenter" 
-      expect(content).to include "class PostErrorsPresenter < Curly::Presenter" 
-      expect(content).to include "class ErrorMessagePresenter < Curly::Presenter" 
+    expect(subject).to generate("app/presenters/articles/form_presenter.rb") {|content|
+      expect(content).to include "class Articles::FormPresenter < Curly::Presenter"
+      expect(content).to include "presents :article"
+      expect(content).to include "def article_errors"
+      expect(content).to include "def article_form(&block)"
+      expect(content).to include "def submit"
+      expect(content).to include "class ArticleFormPresenter < Curly::Presenter"
+      expect(content).to include "class ArticleErrorsPresenter < Curly::Presenter"
+      expect(content).to include "class ErrorMessagePresenter < Curly::Presenter"
     }
   end
 end

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -122,7 +122,7 @@ describe Curly::Presenter do
     end
 
     it "doesn't delegate other calls to the context" do
-      expect { subject.bar }.to raise_error
+      expect { subject.bar }.to raise_error RSpec::Mocks::MockExpectationError
     end
   end
 


### PR DESCRIPTION
The scaffold generator code had the table `post` hard-coded into it.  I fixed the static issue, and changed the tests from looking at `post` to looking at `article`, so any additional errors should appear.  

Also fixed a warning from Spec.