### PR TITLE
Rails 5.2.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* Add support for Rails 5.2.
+
+  *Benjamin Quorning*
+
 ### Curly 2.6.4 (April 28, 2017)
 
 * Add support for Rails 5.1.

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ platform :ruby do
   gem 'yard-tomdoc'
   gem 'redcarpet'
   gem 'github-markup'
-  gem 'rails', '~> 5.2.0.beta2', require: false
+  gem 'rails', '~> 5.2.0', require: false
   gem 'rspec-rails', require: false
   gem 'benchmark-ips', require: false
   gem 'stackprof', require: false

--- a/curly-templates.gemspec
+++ b/curly-templates.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.add_dependency("actionpack", [">= 3.1", "< 5.2"])
+  s.add_dependency("actionpack", [">= 3.1", "< 6.0"])
 
-  s.add_development_dependency("railties", [">= 3.1", "< 5.2"])
+  s.add_development_dependency("railties", [">= 3.1", "< 6.0"])
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec", ">= 3")
   s.add_development_dependency("rspec_junit_formatter")


### PR DESCRIPTION
Let's allow people to bundle Curly when using Rails 5.2.0.