### PR TITLE
Drop support for Rails 4.1 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+* Add support for Rails 6.0 and 6.1.
+* Remove support for Rails versions below 4.2.
+
 ### Curly 2.6.5 (May 23, 2018)
 
 * Add support for Rails 5.2.

--- a/curly-templates.gemspec
+++ b/curly-templates.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.add_dependency("actionpack", [">= 3.1", "< 6.2"])
+  s.add_dependency("actionpack", [">= 4.2", "< 6.2"])
 
-  s.add_development_dependency("railties", [">= 3.1", "< 6.2"])
+  s.add_development_dependency("railties", [">= 4.2", "< 6.2"])
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec", ">= 3")
   s.add_development_dependency("rspec_junit_formatter")

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     curly-templates (2.6.5)
-      actionpack (>= 3.1, < 6.2)
+      actionpack (>= 4.2, < 6.2)
 
 GEM
   remote: https://rubygems.org/
@@ -147,7 +147,7 @@ DEPENDENCIES
   genspec (>= 0.3.0)
   github-markup
   rails (~> 4.2.0)
-  railties (>= 3.1, < 6.2)
+  railties (>= 4.2, < 6.2)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     curly-templates (2.6.5)
-      actionpack (>= 3.1, < 6.2)
+      actionpack (>= 4.2, < 6.2)
 
 GEM
   remote: https://rubygems.org/
@@ -155,7 +155,7 @@ DEPENDENCIES
   genspec (>= 0.3.0)
   github-markup
   rails (~> 5.1.0)
-  railties (>= 3.1, < 6.2)
+  railties (>= 4.2, < 6.2)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     curly-templates (2.6.5)
-      actionpack (>= 3.1, < 6.2)
+      actionpack (>= 4.2, < 6.2)
 
 GEM
   remote: https://rubygems.org/
@@ -163,7 +163,7 @@ DEPENDENCIES
   genspec (>= 0.3.0)
   github-markup
   rails (~> 5.2.0)
-  railties (>= 3.1, < 6.2)
+  railties (>= 4.2, < 6.2)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
   remote: ..
   specs:
     curly-templates (2.6.5)
-      actionpack (>= 3.1, < 6.2)
+      actionpack (>= 4.2, < 6.2)
 
 GEM
   remote: https://rubygems.org/
@@ -185,7 +185,7 @@ DEPENDENCIES
   genspec!
   github-markup
   rails (~> 6.0.0)
-  railties (>= 3.1, < 6.2)
+  railties (>= 4.2, < 6.2)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
   remote: ..
   specs:
     curly-templates (2.6.5)
-      actionpack (>= 3.1, < 6.2)
+      actionpack (>= 4.2, < 6.2)
 
 GEM
   remote: https://rubygems.org/
@@ -188,7 +188,7 @@ DEPENDENCIES
   genspec!
   github-markup
   rails (~> 6.1.0)
-  railties (>= 3.1, < 6.2)
+  railties (>= 4.2, < 6.2)
   rake
   redcarpet
   rspec (>= 3)


### PR DESCRIPTION
I cannot get the tests to run, and most people should use a newer Rails anyway.