### PR TITLE
Add support for Rails 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
           - rails5.2
           - rails6.0
           - rails6.1
+          - rails7.0
         exclude:
           - {ruby: '2.7', gemfile: rails4.2}
+          - {ruby: '2.6', gemfile: rails7.0}
     steps:
       - uses: zendesk/checkout@v3
       - uses: zendesk/setup-ruby@v1

--- a/curly-templates.gemspec
+++ b/curly-templates.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.add_dependency("actionpack", [">= 4.2", "< 6.2"])
+  s.add_dependency("actionpack", [">= 4.2", "< 7.1"])
 
-  s.add_development_dependency("railties", [">= 4.2", "< 6.2"])
+  s.add_development_dependency("railties", [">= 4.2", "< 7.1"])
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec", ">= 3")
   s.add_development_dependency("rspec_junit_formatter")

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.0.0)
-      actionpack (>= 4.2, < 6.2)
+      actionpack (>= 4.2, < 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -147,7 +147,7 @@ DEPENDENCIES
   genspec (>= 0.3.0)
   github-markup
   rails (~> 4.2.0)
-  railties (>= 4.2, < 6.2)
+  railties (>= 4.2, < 7.1)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.0.0)
-      actionpack (>= 4.2, < 6.2)
+      actionpack (>= 4.2, < 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -66,8 +66,12 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.3)
     minitest (5.14.3)
     nio4r (2.5.4)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.1-x86_64-linux)
@@ -146,6 +150,7 @@ GEM
       yard
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-linux
 
@@ -155,7 +160,7 @@ DEPENDENCIES
   genspec (>= 0.3.0)
   github-markup
   rails (~> 5.1.0)
-  railties (>= 4.2, < 6.2)
+  railties (>= 4.2, < 7.1)
   rake
   redcarpet
   rspec (>= 3)
@@ -166,4 +171,4 @@ DEPENDENCIES
   yard-tomdoc
 
 BUNDLED WITH
-   2.2.5
+   2.3.19

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.0.0)
-      actionpack (>= 4.2, < 6.2)
+      actionpack (>= 4.2, < 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -170,7 +170,7 @@ DEPENDENCIES
   genspec (>= 0.3.0)
   github-markup
   rails (~> 5.2.0)
-  railties (>= 4.2, < 6.2)
+  railties (>= 4.2, < 7.1)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile 'common.rb'
 
 gem 'rails', '~> 6.0.0'
-gem 'genspec', github: 'bquorning/genspec', branch: 'rails-6'
+gem 'genspec', github: 'zendesk/genspec', branch: 'rails-7'

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/bquorning/genspec.git
-  revision: ff33bec9df252a6340582676a471c574153abd71
-  branch: rails-6
+  remote: https://github.com/zendesk/genspec.git
+  revision: 228a684f3d4f7e1499c55feb7b022681ad1af342
+  branch: rails-7
   specs:
     genspec (0.3.2)
       rspec (>= 2, < 4)
@@ -11,7 +11,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.0.0)
-      actionpack (>= 4.2, < 6.2)
+      actionpack (>= 4.2, < 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -192,7 +192,7 @@ DEPENDENCIES
   genspec!
   github-markup
   rails (~> 6.0.0)
-  railties (>= 4.2, < 6.2)
+  railties (>= 4.2, < 7.1)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/bquorning/genspec.git
-  revision: ff33bec9df252a6340582676a471c574153abd71
-  branch: rails-6
+  remote: https://github.com/zendesk/genspec.git
+  revision: 228a684f3d4f7e1499c55feb7b022681ad1af342
+  branch: rails-7
   specs:
     genspec (0.3.2)
       rspec (>= 2, < 4)
@@ -11,7 +11,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.0.0)
-      actionpack (>= 4.2, < 6.2)
+      actionpack (>= 4.2, < 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -195,7 +195,7 @@ DEPENDENCIES
   genspec!
   github-markup
   rails (~> 6.1.0)
-  railties (>= 4.2, < 6.2)
+  railties (>= 4.2, < 7.1)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile 'common.rb'
 
-gem 'rails', '~> 6.1.0'
+gem 'rails', '~> 7.0.0'
 gem 'genspec', github: 'zendesk/genspec', branch: 'rails-7'

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,0 +1,209 @@
+GIT
+  remote: https://github.com/zendesk/genspec.git
+  revision: 228a684f3d4f7e1499c55feb7b022681ad1af342
+  branch: rails-7
+  specs:
+    genspec (0.3.2)
+      rspec (>= 2, < 4)
+      thor
+
+PATH
+  remote: ..
+  specs:
+    curly-templates (3.0.0)
+      actionpack (>= 4.2, < 7.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4)
+      actionpack (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4)
+      actionpack (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activestorage (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activesupport (= 7.0.4)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    benchmark-ips (2.10.0)
+    builder (3.2.4)
+    concurrent-ruby (1.1.10)
+    crass (1.0.6)
+    diff-lcs (1.5.0)
+    erubi (1.11.0)
+    github-markup (4.0.1)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.19.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
+    minitest (5.16.3)
+    net-imap (0.3.1)
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.1.3)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.13.9)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    racc (1.6.0)
+    rack (2.2.4)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (7.0.4)
+      actioncable (= 7.0.4)
+      actionmailbox (= 7.0.4)
+      actionmailer (= 7.0.4)
+      actionpack (= 7.0.4)
+      actiontext (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activemodel (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.3)
+      loofah (~> 2.3)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.0.6)
+    redcarpet (3.5.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-rails (6.0.1)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.11)
+      rspec-expectations (~> 3.11)
+      rspec-mocks (~> 3.11)
+      rspec-support (~> 3.11)
+    rspec-support (3.12.0)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    stackprof (0.2.22)
+    thor (1.2.1)
+    timeout (0.3.0)
+    tomparse (0.4.2)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    webrick (1.7.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
+    yard-tomdoc (0.7.1)
+      tomparse (>= 0.4.0)
+      yard
+    zeitwerk (2.6.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  benchmark-ips
+  curly-templates!
+  genspec!
+  github-markup
+  rails (~> 7.0.0)
+  railties (>= 4.2, < 7.1)
+  rake
+  redcarpet
+  rspec (>= 3)
+  rspec-rails
+  rspec_junit_formatter
+  stackprof
+  yard
+  yard-tomdoc
+
+BUNDLED WITH
+   2.3.25

--- a/spec/integration/context_blocks_spec.rb
+++ b/spec/integration/context_blocks_spec.rb
@@ -4,24 +4,49 @@ describe "Context blocks", type: :request do
   example "A context block" do
     get '/new'
 
-    expect(response.body).to have_structure <<-HTML.strip_heredoc
-      <html>
-      <head>
-        <title>Dummy app</title>
-      </head>
-      <body>
-      <header>
-        <h1>Dummy app</h1>
-      </header>
-      <form accept-charset="UTF-8" action="/new" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
-        <div class="field">
-          <b>Name</b> <input id="dashboard_name" name="dashboard[name]" type="text" value="test" />
-        </div>
-      </form>
+    case "#{ActionPack::VERSION::MAJOR}.#{ActionPack::VERSION::MINOR}"
+    when '7.0'
+      expect(response.body).to have_structure <<-HTML.strip_heredoc
+        <html>
+        <head>
+          <title>Dummy app</title>
+        </head>
+        <body>
+        <header>
+          <h1>Dummy app</h1>
+        </header>
+        <form action="/new" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />
+          <div class="field">
+            <b>Name</b> <input value="test" type="text" name="dashboard[name]" id="dashboard_name" />
+          </div>
+        </form>
 
-      <p>Thank you!</p>
-      </body>
-      </html>
-    HTML
+        <p>Thank you!</p>
+        </body>
+        </html>
+      HTML
+    when '4.2', '5.1', '5.2', '6.0', '6.1'
+      expect(response.body).to have_structure <<-HTML.strip_heredoc
+        <html>
+        <head>
+          <title>Dummy app</title>
+        </head>
+        <body>
+        <header>
+          <h1>Dummy app</h1>
+        </header>
+        <form accept-charset="UTF-8" action="/new" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
+          <div class="field">
+            <b>Name</b> <input id="dashboard_name" name="dashboard[name]" type="text" value="test" />
+          </div>
+        </form>
+
+        <p>Thank you!</p>
+        </body>
+        </html>
+      HTML
+    else
+      raise "curly-templates does not support Rails #{ActionPack::VERSION::MAJOR}.#{ActionPack::VERSION::MINOR}"
+    end
   end
 end


### PR DESCRIPTION
Rails 7.0 is only compatible with Ruby 2.7+ so we don't test it with
Ruby 2.6

The form html that Rails 7.0 builds is slightly different compared to other versions of Rails so the html expectation of one test was updated.