### PR TITLE
Add support for Ruby 3.0 & 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         ruby:
           - '2.6'
           - '2.7'
+          - '3.0'
+          - '3.1'
         gemfile:
           - rails4.2
           - rails5.1
@@ -22,8 +24,16 @@ jobs:
           - rails6.1
           - rails7.0
         exclude:
-          - {ruby: '2.7', gemfile: rails4.2}
           - {ruby: '2.6', gemfile: rails7.0}
+          - {ruby: '2.7', gemfile: rails4.2}
+          - {ruby: '3.0', gemfile: rails4.2}
+          - {ruby: '3.0', gemfile: rails5.1}
+          - {ruby: '3.0', gemfile: rails5.2}
+          - {ruby: '3.0', gemfile: rails6.0}
+          - {ruby: '3.1', gemfile: rails4.2}
+          - {ruby: '3.1', gemfile: rails5.1}
+          - {ruby: '3.1', gemfile: rails5.2}
+          - {ruby: '3.1', gemfile: rails6.0}
     steps:
       - uses: zendesk/checkout@v3
       - uses: zendesk/setup-ruby@v1

--- a/curly-templates.gemspec
+++ b/curly-templates.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
 
   s.add_dependency("actionpack", [">= 4.2", "< 7.1"])
+  s.add_dependency("sorted_set")
+
 
   s.add_development_dependency("railties", [">= 4.2", "< 7.1"])
   s.add_development_dependency("rake")

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     curly-templates (3.0.0)
       actionpack (>= 4.2, < 7.1)
+      sorted_set
 
 GEM
   remote: https://rubygems.org/
@@ -62,12 +63,12 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.8.0)
     minitest (5.14.3)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.13.9)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (1.6.13)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -96,6 +97,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (13.0.3)
+    rbtree (0.4.5)
     redcarpet (3.5.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -120,6 +122,10 @@ GEM
     rspec-support (3.10.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    set (1.0.3)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     curly-templates (3.0.0)
       actionpack (>= 4.2, < 7.1)
+      sorted_set
 
 GEM
   remote: https://rubygems.org/
@@ -69,12 +70,12 @@ GEM
     mini_portile2 (2.5.3)
     minitest (5.14.3)
     nio4r (2.5.4)
-    nokogiri (1.11.1)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-linux)
+    nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     racc (1.5.2)
     rack (2.2.3)
@@ -104,6 +105,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (13.0.3)
+    rbtree (0.4.5)
     redcarpet (3.5.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -128,6 +130,10 @@ GEM
     rspec-support (3.10.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    set (1.0.3)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     curly-templates (3.0.0)
       actionpack (>= 4.2, < 7.1)
+      sorted_set
 
 GEM
   remote: https://rubygems.org/
@@ -78,12 +79,12 @@ GEM
     mini_portile2 (2.5.3)
     minitest (5.14.3)
     nio4r (2.5.4)
-    nokogiri (1.11.1)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-linux)
+    nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     racc (1.5.2)
     rack (2.2.3)
@@ -114,6 +115,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (13.0.3)
+    rbtree (0.4.5)
     redcarpet (3.5.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -138,6 +140,10 @@ GEM
     rspec-support (3.10.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    set (1.0.3)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -12,6 +12,7 @@ PATH
   specs:
     curly-templates (3.0.0)
       actionpack (>= 4.2, < 7.1)
+      sorted_set
 
 GEM
   remote: https://rubygems.org/
@@ -97,12 +98,12 @@ GEM
     mini_portile2 (2.5.3)
     minitest (5.14.3)
     nio4r (2.5.4)
-    nokogiri (1.11.1)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-linux)
+    nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     racc (1.5.2)
     rack (2.2.3)
@@ -135,6 +136,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.3)
+    rbtree (0.4.5)
     redcarpet (3.5.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -159,6 +161,10 @@ GEM
     rspec-support (3.10.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    set (1.0.3)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -12,6 +12,7 @@ PATH
   specs:
     curly-templates (3.0.0)
       actionpack (>= 4.2, < 7.1)
+      sorted_set
 
 GEM
   remote: https://rubygems.org/
@@ -101,12 +102,8 @@ GEM
     mini_portile2 (2.5.3)
     minitest (5.14.3)
     nio4r (2.5.4)
-    nokogiri (1.11.1)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
     racc (1.5.2)
     rack (2.2.3)
@@ -139,6 +136,7 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rake (13.0.3)
+    rbtree (0.4.5)
     redcarpet (3.5.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -163,6 +161,10 @@ GEM
     rspec-support (3.10.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    set (1.0.3)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -206,4 +208,4 @@ DEPENDENCIES
   yard-tomdoc
 
 BUNDLED WITH
-   2.3.19
+   2.3.25

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -12,6 +12,7 @@ PATH
   specs:
     curly-templates (3.0.0)
       actionpack (>= 4.2, < 7.1)
+      sorted_set
 
 GEM
   remote: https://rubygems.org/
@@ -145,6 +146,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    rbtree (0.4.5)
     redcarpet (3.5.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -169,6 +171,10 @@ GEM
     rspec-support (3.12.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
+    set (1.0.3)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     stackprof (0.2.22)
     thor (1.2.1)
     timeout (0.3.0)

--- a/lib/curly/presenter.rb
+++ b/lib/curly/presenter.rb
@@ -1,4 +1,5 @@
 require 'curly/presenter_name_error'
+require "sorted_set"
 
 module Curly
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ module CompilationSupport
     details.merge! options.fetch(:details, {})
 
     handler = Curly::TemplateHandler
-    template = ActionView::Template.new(source, identifier, handler, details)
+    template = ActionView::Template.new(source, identifier, handler, **details)
     view = if ActionView::VERSION::MAJOR < 6
              ActionView::Base.new
            else


### PR DESCRIPTION
Add support for Ruby 3.0 & 3.1.

The `sorted_set` gem was removed from the standard library so we need to add it to the gemfiles explicitly.