### PR TITLE
Drop upper limit on Rails, test Rails main, release v3.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
           - rails6.1
           - rails7.0
           - rails7.1
+          - rails_main
     steps:
-      - uses: zendesk/checkout@v4
-      - uses: zendesk/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/test_against_rails_main.yml
+++ b/.github/workflows/test_against_rails_main.yml
@@ -1,0 +1,27 @@
+name: Test against Rails main
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  specs:
+    name: Ruby ${{ matrix.ruby }} using ${{ matrix.gemfile }}
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.3'
+        gemfile:
+          - rails_main
+    steps:
+      - uses: zendesk/checkout@v4
+      - uses: zendesk/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 coverage
 InstalledFiles
+gemfiles/rails_main.gemfile.lock
 lib/bundler/man
 pkg
 rdoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Drop upper limit on Rails, test with Rails main.
 * Drop support for Ruby < 3.1.
 * Drop support for Rails < 6.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+### Curly 3.4.0 (July 2, 2024)
 * Drop upper limit on Rails, test with Rails main.
 * Drop support for Ruby < 3.1.
 * Drop support for Rails < 6.1.

--- a/curly-templates.gemspec
+++ b/curly-templates.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.1"
 
-  s.add_dependency("actionpack", [">= 6.1", "< 7.2"])
+  s.add_dependency("actionpack", ">= 6.1")
   s.add_dependency("sorted_set")
 
-  s.add_development_dependency("railties", [">= 5.1", "< 7.2"])
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec", ">= 3")
 

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: ..
   specs:
-    curly-templates (3.3.0)
+    curly-templates (3.4.0)
       actionpack (>= 6.1)
       sorted_set
 

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.3.0)
-      actionpack (>= 6.1, < 7.2)
+      actionpack (>= 6.1)
       sorted_set
 
 GEM
@@ -205,7 +205,6 @@ DEPENDENCIES
   genspec!
   github-markup
   rails (~> 6.1.0)
-  railties (>= 5.1, < 7.2)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.3.0)
-      actionpack (>= 6.1, < 7.2)
+      actionpack (>= 6.1)
       sorted_set
 
 GEM
@@ -204,7 +204,6 @@ DEPENDENCIES
   genspec!
   github-markup
   rails (~> 7.0.0)
-  railties (>= 5.1, < 7.2)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: ..
   specs:
-    curly-templates (3.3.0)
+    curly-templates (3.4.0)
       actionpack (>= 6.1)
       sorted_set
 

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: ..
   specs:
-    curly-templates (3.3.0)
+    curly-templates (3.4.0)
       actionpack (>= 6.1)
       sorted_set
 

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
   remote: ..
   specs:
     curly-templates (3.3.0)
-      actionpack (>= 6.1, < 7.2)
+      actionpack (>= 6.1)
       sorted_set
 
 GEM
@@ -235,7 +235,6 @@ DEPENDENCIES
   genspec!
   github-markup
   rails (~> 7.1.0)
-  railties (>= 5.1, < 7.2)
   rake
   redcarpet
   rspec (>= 3)

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile 'common.rb'
+
+gem 'rails', github: 'rails/rails', branch: 'main'
+gem 'genspec', github: 'zendesk/genspec', branch: 'rails-8'

--- a/lib/curly/version.rb
+++ b/lib/curly/version.rb
@@ -1,3 +1,3 @@
 module Curly
-  VERSION = "3.3.0"
+  VERSION = "3.4.0"
 end


### PR DESCRIPTION
Release v3.4.0:
 * Drop upper limit on Rails, test with Rails main.
 * Drop support for Ruby < 3.1.
 * Drop support for Rails < 6.1.